### PR TITLE
OIA-2: Add service detectors api and sample detector

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.0.0-alpha1-SNAPSHOT</version>
+        <version>1.0.0-alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>api</artifactId>

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectRequest.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectRequest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.detectors;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+/**
+ * Encapsulates Service Detector Request details.
+ */
+public interface DetectRequest {
+
+    /**
+     * @return the address of the host against with the detector should be invoked.
+     */
+    InetAddress getAddress();
+
+    /**
+     * @return additional attributes stored outside of the detector's configuration that
+     * may be required when running the detector.
+     * These are generated in {@link ServiceDetectorFactory#buildRequest(InetAddress, Map)}
+     */
+    Map<String, String> getRuntimeAttributes();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectResults.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectResults.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.detectors;
+
+/**
+ * Encapsulate service detection results.
+ */
+public interface DetectResults {
+
+    /**
+     * @return true if the service was detected, false otherwise
+     */
+    boolean isServiceDetected();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectorClient.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectorClient.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.detectors;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.integration.api.v1.annotations.Consumable;
+
+/**
+ *  Runs the detector. Implementation is container specific
+ */
+
+@Consumable
+public interface DetectorClient {
+
+    CompletableFuture<Boolean> detect(String serviceName, String hostName, Map<String, String> detectorAttributes);
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetector.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetector.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.detectors;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ *  Service Detectors should implement this interface.
+ *  {@link ServiceDetectorFactory} is responsible for instantiating {@link ServiceDetector}
+ */
+public interface ServiceDetector {
+
+    /**
+     * Perform any necessary initialization after construction and before detecting.
+     */
+    void init();
+
+    /**
+     * Requires that all implementations of this API return a service name.
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    String getServiceName();
+
+
+    /**
+     * The detector should clean up after itself in this method if necessary.
+     */
+    void dispose();
+
+
+    /**
+     * Performs detection of the service and returns result as future.
+     * @param request {@link DetectRequest}
+     * @return a {@link CompletableFuture} with {@link DetectResults}
+     */
+    CompletableFuture<DetectResults> detect(DetectRequest request);
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
@@ -42,7 +42,8 @@ public interface ServiceDetectorFactory<T extends ServiceDetector> {
 
     /**
      * Instantiates a new detector and set bean properties.
-     * One of the ways to set bean properties is by using Spring BeanWrapper.
+     * Bean properties like "port", "username" can be set on detector from properties.
+     * They can be set individually by calling each setter or by using Spring Beanwrapper as below.
      * <pre>
      * {@code
      *         BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(serviceDetector);

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
@@ -41,14 +41,25 @@ import org.opennms.integration.api.v1.annotations.Exposable;
 public interface ServiceDetectorFactory<T extends ServiceDetector> {
 
     /**
-     * Instantiates a new detector.
-     * <p>
-     * Detectors are treated as protoypes.
+     * Instantiates a new detector and set bean properties.
+     * One of the ways to set bean properties is by using Spring BeanWrapper.
+     * <pre>
+     * {@code
+     *         BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(serviceDetector);
+     *         wrapper.setPropertyValues(properties);
+     * }
+     * </pre>
+     * Detectors are treated as protoypes meaning there will be a new instance of detector each time createDetector gets called.
+     * @param properties  are used to set properties on detector bean.
+     *
+     * @return a new @{@link ServiceDetector}.
      */
-    T createDetector();
+    T createDetector(Map<String, String> properties);
 
     /**
      * Used by the detector registry to track and index the detector types.
+     *
+     * @return a @{@link Class} for the detector.
      */
     Class<T> getDetectorClass();
 

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.detectors;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+import org.opennms.integration.api.v1.annotations.Exposable;
+
+/**
+ *  Responsible for instantiating service detectors.
+ * @param <T> Class that implements {@link ServiceDetector}
+ */
+@Exposable
+public interface ServiceDetectorFactory<T extends ServiceDetector> {
+
+    /**
+     * Instantiates a new detector.
+     * <p>
+     * Detectors are treated as protoypes.
+     */
+    T createDetector();
+
+    /**
+     * Used by the detector registry to track and index the detector types.
+     */
+    Class<T> getDetectorClass();
+
+    /**
+     * Builds the request that will be used to invoke the detector.
+     *
+     * @param address address of the agent against which the detector will be invoked
+     * @param attributes detector attributes that are supplied as detector parameters in foreign sources configuration
+     *
+     * @return a new {@link DetectRequest} consisting of address and runtime attributes.
+     *
+     */
+    DetectRequest buildRequest(InetAddress address, Map<String, String> attributes);
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/health/HealthCheck.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/health/HealthCheck.java
@@ -58,6 +58,8 @@ public interface HealthCheck {
      * The response indicates if the check was successful, or encountered other problems. If null is returned,
      * the HealthCheckService should consider this as {@link Status#Unknown}.
      *
+     * @param context a @{@link Context} which consists timeout value.
+     *
      * @return The response indicating the Success/Failure/Timeout/etc of the check
      * @throws Exception In case of an error
      */

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.0.0-alpha1-SNAPSHOT</version>
+        <version>1.0.0-alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>common</artifactId>

--- a/karaf-features/pom.xml
+++ b/karaf-features/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.0.0-alpha1-SNAPSHOT</version>
+        <version>1.0.0-alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>karaf-features</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.opennms.integration.api</groupId>
     <artifactId>api-project</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-alpha1-SNAPSHOT</version>
+    <version>1.0.0-alpha2-SNAPSHOT</version>
     <name>OpenNMS Integration API</name>
     <url>https://github.com/OpenNMS/opennms-integration-api</url>
     <description>Integration and extension API for OpenNMS</description>
@@ -49,7 +49,6 @@
         <karaf.version>4.1.5</karaf.version>
         <log4j.version>2.8.2</log4j.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
-        <spring.version>4.3.14.RELEASE_1</spring.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <karaf.version>4.1.5</karaf.version>
         <log4j.version>2.8.2</log4j.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
+        <spring.version>4.3.14.RELEASE_1</spring.version>
     </properties>
 
     <dependencyManagement>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.0.0-alpha1-SNAPSHOT</version>
+        <version>1.0.0-alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.integration.api.sample</groupId>
@@ -28,16 +28,5 @@
             <artifactId>test-api</artifactId>
             <scope>test</scope>
         </dependency>
-      <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.spring-beans</artifactId>
-        <version>${spring.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.spring-core</artifactId>
-        <version>${spring.version}</version>
-      </dependency>
     </dependencies>
 </project>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -28,5 +28,16 @@
             <artifactId>test-api</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>org.apache.servicemix.bundles.spring-beans</artifactId>
+        <version>${spring.version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>org.apache.servicemix.bundles.spring-core</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
     </dependencies>
 </project>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleDetector.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleDetector.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.sample;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.CompletableFuture;
+
+import org.opennms.integration.api.v1.detectors.DetectRequest;
+import org.opennms.integration.api.v1.detectors.DetectResults;
+import org.opennms.integration.api.v1.detectors.ServiceDetector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sample detector will detect the service if request is for localhost
+ */
+public class SampleDetector implements ServiceDetector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MyAlarmLifecycleListener.class);
+
+    public static final String SERVICE_NAME = "Sample";
+    public static final String DEFAULT_HOST_NAME = "localhost";
+    public static final String DEFAULT_USERNAME_PROPERTY = "username";
+    public static final String DEFAULT_USERNAME_VALUE = "admin";
+    public static final String DEFAULT_PASSWORD_PROPERTY = "password";
+    public static final String DEFAULT_PASSWORD_VALUE = "admin";
+
+    private String username;
+
+    private String password;
+
+
+    @Override
+    public void init() {
+        //pass
+    }
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+
+    @Override
+    public void dispose() {
+        //pass
+    }
+
+    @Override
+    public CompletableFuture<DetectResults> detect(DetectRequest request) {
+        try {
+            if (request.getAddress().equals(InetAddress.getLocalHost())) {
+                return CompletableFuture.completedFuture(new DetectResults() {
+                    @Override
+                    public boolean isServiceDetected() {
+                        LOG.info(" {} service detected on {} ", getServiceName(), request.getAddress());
+                        if (getUsername().equals(DEFAULT_USERNAME_VALUE) && getPassword().equals(DEFAULT_PASSWORD_VALUE) &&
+                                request.getRuntimeAttributes().get(SampleDetectorFactory.PROTOCOL_ATTRIBUTE).equals(SampleDetectorFactory.PROTOCOL_VALUE)) {
+                            return true;
+                        }
+                        return false;
+                    }
+                });
+            }
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException(request.getAddress().getHostName());
+        }
+        return CompletableFuture.completedFuture(new DetectResults() {
+            @Override
+            public boolean isServiceDetected() {
+                LOG.info(" {} service not detected on {} ", getServiceName(), request.getAddress());
+                return false;
+            }
+        });
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2018 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2018 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.sample;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opennms.integration.api.v1.detectors.DetectRequest;
+import org.opennms.integration.api.v1.detectors.ServiceDetectorFactory;
+
+public class SampleDetectorFactory implements ServiceDetectorFactory<SampleDetector> {
+
+    public static  String PROTOCOL_ATTRIBUTE = "protocol";
+    public static  String PROTOCOL_VALUE  = "rmi";
+
+    @Override
+    public SampleDetector createDetector() {
+        return new SampleDetector();
+    }
+
+    @Override
+    public Class<SampleDetector> getDetectorClass() {
+        return SampleDetector.class;
+    }
+
+    @Override
+    public DetectRequest buildRequest(InetAddress address, Map<String, String> attributes) {
+        return new DetectRequest() {
+            @Override
+            public InetAddress getAddress() {
+                return address;
+            }
+
+            @Override
+            public Map<String, String> getRuntimeAttributes() {
+                // new runtime attributes can be generated in factory.
+                Map<String, String> attributes = new HashMap<>();
+                attributes.put(PROTOCOL_ATTRIBUTE, PROTOCOL_VALUE);
+                return attributes;
+            }
+        };
+    }
+}

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
@@ -28,14 +28,15 @@
 
 package org.opennms.integration.api.sample;
 
+import static org.opennms.integration.api.sample.SampleDetector.DEFAULT_PASSWORD_PROPERTY;
+import static org.opennms.integration.api.sample.SampleDetector.DEFAULT_USERNAME_PROPERTY;
+
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.opennms.integration.api.v1.detectors.DetectRequest;
 import org.opennms.integration.api.v1.detectors.ServiceDetectorFactory;
-import org.springframework.beans.BeanWrapper;
-import org.springframework.beans.PropertyAccessorFactory;
 
 public class SampleDetectorFactory implements ServiceDetectorFactory<SampleDetector> {
 
@@ -46,8 +47,12 @@ public class SampleDetectorFactory implements ServiceDetectorFactory<SampleDetec
     public SampleDetector createDetector(Map<String, String> properties) {
 
         SampleDetector sampleDetector = new SampleDetector();
-        BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(sampleDetector);
-        wrapper.setPropertyValues(properties);
+        if(properties.get(DEFAULT_USERNAME_PROPERTY) != null) {
+            sampleDetector.setUsername(properties.get(DEFAULT_USERNAME_PROPERTY));
+        }
+        if(properties.get(DEFAULT_PASSWORD_PROPERTY) != null) {
+            sampleDetector.setPassword(properties.get(DEFAULT_PASSWORD_PROPERTY));
+        }
         return sampleDetector;
     }
 

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
@@ -34,6 +34,8 @@ import java.util.Map;
 
 import org.opennms.integration.api.v1.detectors.DetectRequest;
 import org.opennms.integration.api.v1.detectors.ServiceDetectorFactory;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.PropertyAccessorFactory;
 
 public class SampleDetectorFactory implements ServiceDetectorFactory<SampleDetector> {
 
@@ -41,8 +43,12 @@ public class SampleDetectorFactory implements ServiceDetectorFactory<SampleDetec
     public static  String PROTOCOL_VALUE  = "rmi";
 
     @Override
-    public SampleDetector createDetector() {
-        return new SampleDetector();
+    public SampleDetector createDetector(Map<String, String> properties) {
+
+        SampleDetector sampleDetector = new SampleDetector();
+        BeanWrapper wrapper = PropertyAccessorFactory.forBeanPropertyAccess(sampleDetector);
+        wrapper.setPropertyValues(properties);
+        return sampleDetector;
     }
 
     @Override

--- a/sample/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/sample/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -7,7 +7,7 @@
     <reference id="nodeDao" interface="org.opennms.integration.api.v1.dao.NodeDao" />
     <reference id="snmpInterfaceDao" interface="org.opennms.integration.api.v1.dao.SnmpInterfaceDao" />
     <reference id="eventForwarder" interface="org.opennms.integration.api.v1.events.EventForwarder" />
-
+    <reference id="detectorClient" interface="org.opennms.integration.api.v1.detectors.DetectorClient" />
 
     <bean id="alarmManager" class="org.opennms.integration.api.sample.SampleAlarmManager"/>
 
@@ -22,6 +22,7 @@
         <bean class="org.opennms.integration.api.sample.MyHealthCheck">
             <argument ref="alarmManager"/>
             <argument ref="eventForwarder"/>
+            <argument ref="detectorClient"/>
         </bean>
     </service>
 
@@ -43,6 +44,10 @@
 
     <service interface="org.opennms.integration.api.v1.config.syslog.SyslogMatchExtension">
         <bean class="org.opennms.integration.api.sample.MySyslogMatchExtension"/>
+    </service>
+
+    <service interface="org.opennms.integration.api.v1.detectors.ServiceDetectorFactory">
+        <bean class="org.opennms.integration.api.sample.SampleDetectorFactory"/>
     </service>
 
 </blueprint>

--- a/test-api/pom.xml
+++ b/test-api/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.0.0-alpha1-SNAPSHOT</version>
+        <version>1.0.0-alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>test-api</artifactId>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.0.0-alpha1-SNAPSHOT</version>
+        <version>1.0.0-alpha2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>xml</artifactId>


### PR DESCRIPTION
Changes to service detecor API from provision:
removed setters, removed getIpMatch() as I see this is only used in LoopDetector so it may not be generic.
removed getServiceAttributes() as this is used only in WsManDetector. 
service detector is always async in nature.

https://issues.opennms.org/browse/OIA-2