### PR TITLE
OCE-55: Add topology(link) support to the OpenNMS Direct datasource

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -1,6 +1,6 @@
 
 # API Development Guidelines
 
-* All interfaces in the 'api' module should contain a the version in which they were introduced using a `@since` tag in the interfaces Javadoc
+* All interfaces in the 'api' module should contain the version in which they were introduced using a `@since` tag in the interface's Javadoc
 * Interfaces which are expected to be exposed in the OSGi registry by the API users should be annotated with the `org.opennms.integration.api.v1.annotations.Exposable` annotation
 * Interfaces which are expected to be consumed from the OSGi registry by the API users should be annotated with the `org.opennms.integration.api.v1.annotations.Consumable` annotation

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import org.opennms.integration.api.v1.annotations.Consumable;
 import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 
 /**
  * Lookup edges.
@@ -50,7 +51,7 @@ public interface EdgeDao {
      * @param protocol the protocol to filter by
      * @return the count of edges corresponding to the given protocol
      */
-    long getEdgeCount(String protocol);
+    long getEdgeCount(TopologyProtocol protocol);
 
     /**
      * @return a collection of all the edges
@@ -61,10 +62,10 @@ public interface EdgeDao {
      * @param protocol the protocol to filter by
      * @return the edges corresponding to the given protocol
      */
-    Collection<TopologyEdge> getEdges(String protocol);
+    Collection<TopologyEdge> getEdges(TopologyProtocol protocol);
 
     /**
      * @return the set of protocols currently known to the dao
      */
-    Set<String> getProtocols();
+    Set<TopologyProtocol> getProtocols();
 }

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.dao;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.opennms.integration.api.v1.annotations.Consumable;
+import org.opennms.integration.api.v1.model.TopologyEdge;
+
+/**
+ * Lookup edges.
+ *
+ * @since 1.0.0
+ */
+@Consumable
+public interface EdgeDao {
+    /**
+     * @return the count of all edges
+     */
+    long getEdgeCount();
+
+    /**
+     * @param protocol the protocol to filter by
+     * @return the count of edges corresponding to the given protocol
+     */
+    long getEdgeCount(String protocol);
+
+    /**
+     * @return a collection of all the edges
+     */
+    Collection<TopologyEdge> getEdges();
+
+    /**
+     * @param protocol the protocol to filter by
+     * @return the edges corresponding to the given protocol
+     */
+    Collection<TopologyEdge> getEdges(String protocol);
+
+    /**
+     * @return the set of protocols currently known to the dao
+     */
+    Set<String> getProtocols();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/model/NodeCriteria.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/NodeCriteria.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model;
+
+/**
+ * @author mbrooks
+ * @since 1.0.0
+ */
+public interface NodeCriteria {
+    Integer getId();
+
+    String getForeignSource();
+
+    String getForeignId();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model;
+
+/**
+ * @author mbrooks
+ * @since 1.0.0
+ */
+public interface TopologyEdge extends TopologyRef {
+    String getProtocol();
+
+    TopologyPort getSource();
+
+    /**
+     * Visit the target that this edge is connected to. The {@link TopologyEdgeTargetVisitor visitor} will be called
+     * with {@link TopologyEdgeTargetVisitor#visitTargetPort(TopologyPort)} or
+     * {@link TopologyEdgeTargetVisitor#visitTargetSegement(TopologySegment)} depending on what type of target this edge
+     * is connected to.
+     *
+     * @param v the visitor
+     */
+    void visitTarget(TopologyEdgeTargetVisitor v);
+
+    /**
+     * A visitor for accessing the target this edge is connected to which can be typed to either a
+     * {@link TopologyPort port} or a {@link TopologySegment segment}.
+     */
+    interface TopologyEdgeTargetVisitor {
+        default void visitTargetPort(TopologyPort port) {
+        }
+
+        default void visitTargetSegement(TopologySegment segment) {
+        }
+    }
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
@@ -33,7 +33,7 @@ package org.opennms.integration.api.v1.model;
  * @since 1.0.0
  */
 public interface TopologyEdge extends TopologyRef {
-    String getProtocol();
+    TopologyProtocol getProtocol();
 
     TopologyPort getSource();
 

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyPort.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyPort.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model;
+
+/**
+ * @author mbrooks
+ * @since 1.0.0
+ */
+public interface TopologyPort extends TopologyRef {
+    Integer getIfIndex();
+
+    String getIfName();
+
+    String getIfAddress();
+
+    NodeCriteria getNodeCriteria();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
@@ -29,14 +29,25 @@
 package org.opennms.integration.api.v1.model;
 
 /**
- * @author mbrooks
- * @since 1.0.0
+ * The set of protocols supported by OpenNMS topology.
  */
-public interface TopologySegment extends TopologyRef {
-    TopologyProtocol getProtocol();
-
+public enum TopologyProtocol {
     /**
-     * @return the segment criteria, a string in the format of "protocol:Id"
+     * A special value representing all protocols.
      */
-    String getSegmentCriteria();
+    ALL,
+
+    BRIDGE,
+
+    CDP,
+
+    ISIS,
+
+    LLDP,
+
+    NODES,
+
+    OSPF,
+
+    USERDEFINED
 }

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyRef.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyRef.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model;
+
+/**
+ * @author mbrooks
+ * @since 1.0.0
+ */
+public interface TopologyRef {
+    String getId();
+
+    String getTooltipText();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologySegment.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologySegment.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model;
+
+/**
+ * @author mbrooks
+ * @since 1.0.0
+ */
+public interface TopologySegment extends TopologyRef {
+    String getProtocol();
+
+    String getSegmentCriteria();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/topology/TopologyEdgeConsumer.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/topology/TopologyEdgeConsumer.java
@@ -28,8 +28,11 @@
 
 package org.opennms.integration.api.v1.topology;
 
+import java.util.Set;
+
 import org.opennms.integration.api.v1.annotations.Exposable;
 import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 
 /**
  * Implementations of this interface will receive {@link TopologyEdge edges} from OpenNMS.
@@ -52,8 +55,10 @@ public interface TopologyEdgeConsumer {
     /**
      * Provides the list of protocols that this consumer supports. Only edges corresponding to the given protocols will
      * be sent via {@link #onEdgeAddedOrUpdated(TopologyEdge)} and {@link #onEdgeDeleted(TopologyEdge)}.
+     * <p>
+     * To be sent updates for all protocols include {@link TopologyProtocol#ALL}.
      *
-     * @return the comma separated list of protocols this consumer supports
+     * @return the set of protocols this consumer supports
      */
-    String getProtocols();
+    Set<TopologyProtocol> getProtocols();
 }

--- a/api/src/main/java/org/opennms/integration/api/v1/topology/TopologyEdgeConsumer.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/topology/TopologyEdgeConsumer.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.topology;
+
+import org.opennms.integration.api.v1.annotations.Exposable;
+import org.opennms.integration.api.v1.model.TopologyEdge;
+
+/**
+ * Implementations of this interface will receive {@link TopologyEdge edges} from OpenNMS.
+ *
+ * @author mbrooks
+ * @since 1.0.0
+ */
+@Exposable
+public interface TopologyEdgeConsumer {
+    /**
+     * @param topologyEdge the edge being added or updated
+     */
+    void onEdgeAddedOrUpdated(TopologyEdge topologyEdge);
+
+    /**
+     * @param topologyEdge the edge being deleted
+     */
+    void onEdgeDeleted(TopologyEdge topologyEdge);
+
+    /**
+     * Provides the list of protocols that this consumer supports. Only edges corresponding to the given protocols will
+     * be sent via {@link #onEdgeAddedOrUpdated(TopologyEdge)} and {@link #onEdgeDeleted(TopologyEdge)}.
+     *
+     * @return the comma separated list of protocols this consumer supports
+     */
+    String getProtocols();
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.NodeCriteria;
+
+public final class ImmutableNodeCriteria implements NodeCriteria {
+    private final Integer id;
+    private final String foreignSource;
+    private final String foreignId;
+
+    private ImmutableNodeCriteria(Builder builder) {
+        this.id = builder.id;
+        this.foreignSource = builder.foreignSource;
+        this.foreignId = builder.foreignId;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Integer id;
+        private String foreignSource;
+        private String foreignId;
+
+        private Builder() {
+        }
+
+        public Builder setId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setForeignSource(String foreignSource) {
+            this.foreignSource = foreignSource;
+            return this;
+        }
+
+        public Builder setForeignId(String foreignId) {
+            this.foreignId = foreignId;
+            return this;
+        }
+
+        public ImmutableNodeCriteria build() {
+            if (id == null && (foreignSource == null || foreignId == null)) {
+                throw new IllegalStateException("Id is null but foreign source or foreign Id is not specified");
+            }
+            if (foreignSource != null && foreignId == null) {
+                throw new NullPointerException("Foreign Id must be set when foreign source is set");
+            }
+            if (foreignId != null && foreignSource == null) {
+                throw new NullPointerException("Foreign source must be set when foreign Id is set");
+            }
+            return new ImmutableNodeCriteria(this);
+        }
+    }
+
+    @Override
+    public Integer getId() {
+        return id;
+    }
+
+    @Override
+    public String getForeignSource() {
+        return foreignSource;
+    }
+
+    @Override
+    public String getForeignId() {
+        return foreignId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableNodeCriteria that = (ImmutableNodeCriteria) o;
+        return id == that.id &&
+                Objects.equals(foreignSource, that.foreignSource) &&
+                Objects.equals(foreignId, that.foreignId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, foreignSource, foreignId);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableNodeCriteria{" +
+                "id=" + id +
+                ", foreignSource='" + foreignSource + '\'' +
+                ", foreignId='" + foreignId + '\'' +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
@@ -32,10 +32,11 @@ import java.util.Objects;
 
 import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.integration.api.v1.model.TopologyPort;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.model.TopologySegment;
 
 public final class ImmutableTopologyEdge implements TopologyEdge {
-    private final String protocol;
+    private final TopologyProtocol protocol;
     private final String id;
     private final String tooltipText;
     private final TopologyPort source;
@@ -56,7 +57,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
     }
 
     public static class Builder {
-        private String protocol;
+        private TopologyProtocol protocol;
         private String id;
         private String tooltipText;
         private TopologyPort source;
@@ -66,7 +67,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
         private Builder() {
         }
 
-        public Builder setProtocol(String protocol) {
+        public Builder setProtocol(TopologyProtocol protocol) {
             this.protocol = Objects.requireNonNull(protocol);
             return this;
         }
@@ -110,7 +111,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
     }
 
     @Override
-    public String getProtocol() {
+    public TopologyProtocol getProtocol() {
         return protocol;
     }
 

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyPort;
+import org.opennms.integration.api.v1.model.TopologySegment;
+
+public final class ImmutableTopologyEdge implements TopologyEdge {
+    private final String protocol;
+    private final String id;
+    private final String tooltipText;
+    private final TopologyPort source;
+    private final TopologyPort targetPort;
+    private final TopologySegment targetSegment;
+
+    private ImmutableTopologyEdge(Builder builder) {
+        this.protocol = builder.protocol;
+        this.id = builder.id;
+        this.tooltipText = builder.tooltipText;
+        this.source = builder.source;
+        this.targetPort = builder.targetPort;
+        this.targetSegment = builder.targetSegment;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String protocol;
+        private String id;
+        private String tooltipText;
+        private TopologyPort source;
+        private TopologyPort targetPort;
+        private TopologySegment targetSegment;
+
+        private Builder() {
+        }
+
+        public Builder setProtocol(String protocol) {
+            this.protocol = Objects.requireNonNull(protocol);
+            return this;
+        }
+
+        public Builder setId(String id) {
+            this.id = Objects.requireNonNull(id);
+            return this;
+        }
+
+        public Builder setTooltipText(String tooltipText) {
+            this.tooltipText = tooltipText;
+            return this;
+        }
+
+        public Builder setSource(TopologyPort source) {
+            this.source = Objects.requireNonNull(source);
+            return this;
+        }
+
+        public Builder setTargetPort(TopologyPort targetPort) {
+            this.targetPort = targetPort;
+            return this;
+        }
+
+        public Builder setTargetSegment(TopologySegment targetSegment) {
+            this.targetSegment = targetSegment;
+            return this;
+        }
+
+        public ImmutableTopologyEdge build() {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(protocol);
+            if (targetPort == null && targetSegment == null) {
+                throw new NullPointerException("Edge must have a target");
+            }
+            if (targetPort != null && targetSegment != null) {
+                throw new IllegalStateException("Edge cannot have both a target port and a target segment");
+            }
+            return new ImmutableTopologyEdge(this);
+        }
+    }
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getTooltipText() {
+        return tooltipText;
+    }
+
+    @Override
+    public TopologyPort getSource() {
+        return source;
+    }
+
+    @Override
+    public void visitTarget(TopologyEdgeTargetVisitor v) {
+        if (targetPort != null) {
+            v.visitTargetPort(targetPort);
+        } else {
+            v.visitTargetSegement(targetSegment);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableTopologyEdge that = (ImmutableTopologyEdge) o;
+        return Objects.equals(protocol, that.protocol) &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(tooltipText, that.tooltipText) &&
+                Objects.equals(source, that.source) &&
+                Objects.equals(targetPort, that.targetPort) &&
+                Objects.equals(targetSegment, that.targetSegment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(protocol, id, tooltipText, source, targetPort, targetSegment);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableTopologyEdge{" +
+                "protocol='" + protocol + '\'' +
+                ", id='" + id + '\'' +
+                ", tooltipText='" + tooltipText + '\'' +
+                ", source=" + source +
+                ", targetPort=" + targetPort +
+                ", targetSegment=" + targetSegment +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.NodeCriteria;
+import org.opennms.integration.api.v1.model.TopologyPort;
+
+public final class ImmutableTopologyPort implements TopologyPort {
+    private final String id;
+    private final String tooltipText;
+    private final Integer ifIndex;
+    private final String ifName;
+    private final String ifAddress;
+    private final NodeCriteria nodeCriteria;
+
+    private ImmutableTopologyPort(Builder builder) {
+        this.id = builder.id;
+        this.tooltipText = builder.tooltipText;
+        this.ifIndex = builder.ifIndex;
+        this.ifName = builder.ifName;
+        this.ifAddress = builder.ifAddress;
+        this.nodeCriteria = builder.nodeCriteria;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String id;
+        private String tooltipText;
+        private Integer ifIndex;
+        private String ifName;
+        private String ifAddress;
+        private NodeCriteria nodeCriteria;
+
+        private Builder() {
+        }
+
+        public Builder setId(String id) {
+            this.id = Objects.requireNonNull(id);
+            return this;
+        }
+
+        public Builder setTooltipText(String tooltipText) {
+            this.tooltipText = tooltipText;
+            return this;
+        }
+
+        public Builder setIfIndex(Integer ifIndex) {
+            this.ifIndex = Objects.requireNonNull(ifIndex);
+            return this;
+        }
+
+        public Builder setIfName(String ifName) {
+            this.ifName = ifName;
+            return this;
+        }
+
+        public Builder setIfAddress(String ifAddress) {
+            this.ifAddress = ifAddress;
+            return this;
+        }
+
+        public Builder setNodeCriteria(NodeCriteria nodeCriteria) {
+            this.nodeCriteria = nodeCriteria;
+            return this;
+        }
+
+        public ImmutableTopologyPort build() {
+            Objects.requireNonNull(id);
+            return new ImmutableTopologyPort(this);
+        }
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getTooltipText() {
+        return tooltipText;
+    }
+
+    @Override
+    public Integer getIfIndex() {
+        return ifIndex;
+    }
+
+    @Override
+    public String getIfName() {
+        return ifName;
+    }
+
+    @Override
+    public String getIfAddress() {
+        return ifAddress;
+    }
+
+    @Override
+    public NodeCriteria getNodeCriteria() {
+        return nodeCriteria;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableTopologyPort that = (ImmutableTopologyPort) o;
+        return ifIndex == that.ifIndex &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(tooltipText, that.tooltipText) &&
+                Objects.equals(ifName, that.ifName) &&
+                Objects.equals(ifAddress, that.ifAddress) &&
+                Objects.equals(nodeCriteria, that.nodeCriteria);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, tooltipText, ifIndex, ifName, ifAddress, nodeCriteria);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableTopologyPort{" +
+                "id='" + id + '\'' +
+                ", tooltipText='" + tooltipText + '\'' +
+                ", ifIndex=" + ifIndex +
+                ", ifName='" + ifName + '\'' +
+                ", ifAddress='" + ifAddress + '\'' +
+                ", nodeCriteria=" + nodeCriteria +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
@@ -30,11 +30,12 @@ package org.opennms.integration.api.v1.model.immutables;
 
 import java.util.Objects;
 
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.model.TopologySegment;
 
 public final class ImmutableTopologySegment implements TopologySegment {
     private final String id;
-    private final String protocol;
+    private final TopologyProtocol protocol;
     private final String tooltipText;
 
     private ImmutableTopologySegment(Builder builder) {
@@ -50,7 +51,7 @@ public final class ImmutableTopologySegment implements TopologySegment {
     public static class Builder {
         private String id;
         private String tooltipText;
-        private String protocol;
+        private TopologyProtocol protocol;
 
         private Builder() {
         }
@@ -60,7 +61,7 @@ public final class ImmutableTopologySegment implements TopologySegment {
             return this;
         }
 
-        public Builder setProtocol(String protocol) {
+        public Builder setProtocol(TopologyProtocol protocol) {
             this.protocol = Objects.requireNonNull(protocol);
             return this;
         }
@@ -88,7 +89,7 @@ public final class ImmutableTopologySegment implements TopologySegment {
     }
 
     @Override
-    public String getProtocol() {
+    public TopologyProtocol getProtocol() {
         return protocol;
     }
 

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.TopologySegment;
+
+public final class ImmutableTopologySegment implements TopologySegment {
+    private final String id;
+    private final String protocol;
+    private final String tooltipText;
+
+    private ImmutableTopologySegment(Builder builder) {
+        this.id = builder.id;
+        this.tooltipText = builder.tooltipText;
+        this.protocol = builder.protocol;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String id;
+        private String tooltipText;
+        private String protocol;
+
+        private Builder() {
+        }
+
+        public Builder setId(String id) {
+            this.id = Objects.requireNonNull(id);
+            return this;
+        }
+
+        public Builder setProtocol(String protocol) {
+            this.protocol = Objects.requireNonNull(protocol);
+            return this;
+        }
+
+        public Builder setTooltipText(String tooltipText) {
+            this.tooltipText = tooltipText;
+            return this;
+        }
+
+        public ImmutableTopologySegment build() {
+            Objects.requireNonNull(id);
+            Objects.requireNonNull(protocol);
+            return new ImmutableTopologySegment(this);
+        }
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getTooltipText() {
+        return tooltipText;
+    }
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    @Override
+    public String getSegmentCriteria() {
+        return String.format("%s:%s", protocol, id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableTopologySegment that = (ImmutableTopologySegment) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(protocol, that.protocol) &&
+                Objects.equals(tooltipText, that.tooltipText);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, protocol, tooltipText);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableTopologySegment{" +
+                "id='" + id + '\'' +
+                ", protocol='" + protocol + '\'' +
+                ", tooltipText='" + tooltipText + '\'' +
+                '}';
+    }
+}

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyTopologyEdgeConsumer.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyTopologyEdgeConsumer.java
@@ -28,7 +28,11 @@
 
 package org.opennms.integration.api.sample;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.topology.TopologyEdgeConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +51,7 @@ public class MyTopologyEdgeConsumer implements TopologyEdgeConsumer {
     }
 
     @Override
-    public String getProtocols() {
-        return "bridge,cdp,isis,lldp,ospf,userdefined";
+    public Set<TopologyProtocol> getProtocols() {
+        return Collections.singleton(TopologyProtocol.ALL);
     }
 }

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyTopologyEdgeConsumer.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyTopologyEdgeConsumer.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.sample;
+
+import org.opennms.integration.api.v1.model.TopologyEdge;
+import org.opennms.integration.api.v1.topology.TopologyEdgeConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MyTopologyEdgeConsumer implements TopologyEdgeConsumer {
+    private static final Logger LOG = LoggerFactory.getLogger(MyTopologyEdgeConsumer.class);
+
+    @Override
+    public void onEdgeAddedOrUpdated(TopologyEdge topologyEdge) {
+        LOG.info("Received add/update for edge: {}", topologyEdge);
+    }
+
+    @Override
+    public void onEdgeDeleted(TopologyEdge topologyEdge) {
+        LOG.info("Received delete for edge: {}", topologyEdge);
+    }
+
+    @Override
+    public String getProtocols() {
+        return "bridge,cdp,isis,lldp,ospf,userdefined";
+    }
+}

--- a/sample/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/sample/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -112,4 +112,8 @@
         </bean>
     </service>
 
+    <service interface="org.opennms.integration.api.v1.topology.TopologyEdgeConsumer">
+        <bean class="org.opennms.integration.api.sample.MyTopologyEdgeConsumer"/>
+    </service>
+
 </blueprint>


### PR DESCRIPTION
- Added support to the integration API for clients to receive edges from OpenNMS topology

Note: I didn't bump the version, not sure if that is required for these changes.

Tested manually during feature test of links over the API.

Jira: https://issues.opennms.org/browse/OCE-55