### PR TITLE
OCE-55: Refactor API to allow edges to have different types of sources and targets

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
@@ -28,7 +28,6 @@
 
 package org.opennms.integration.api.v1.dao;
 
-import java.util.Collection;
 import java.util.Set;
 
 import org.opennms.integration.api.v1.annotations.Consumable;
@@ -54,15 +53,15 @@ public interface EdgeDao {
     long getEdgeCount(TopologyProtocol protocol);
 
     /**
-     * @return a collection of all the edges
+     * @return a set of all the edges
      */
-    Collection<TopologyEdge> getEdges();
+    Set<TopologyEdge> getEdges();
 
     /**
      * @param protocol the protocol to filter by
      * @return the edges corresponding to the given protocol
      */
-    Collection<TopologyEdge> getEdges(TopologyProtocol protocol);
+    Set<TopologyEdge> getEdges(TopologyProtocol protocol);
 
     /**
      * @return the set of protocols currently known to the dao

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
@@ -35,27 +35,44 @@ package org.opennms.integration.api.v1.model;
 public interface TopologyEdge extends TopologyRef {
     TopologyProtocol getProtocol();
 
-    TopologyPort getSource();
-
     /**
-     * Visit the target that this edge is connected to. The {@link TopologyEdgeTargetVisitor visitor} will be called
-     * with {@link TopologyEdgeTargetVisitor#visitTargetPort(TopologyPort)} or
-     * {@link TopologyEdgeTargetVisitor#visitTargetSegement(TopologySegment)} depending on what type of target this edge
-     * is connected to.
+     * Visit the endpoints that this edge is connected to.
      *
      * @param v the visitor
      */
-    void visitTarget(TopologyEdgeTargetVisitor v);
+    void visitEndpoints(EndpointVisitor v);
 
     /**
-     * A visitor for accessing the target this edge is connected to which can be typed to either a
-     * {@link TopologyPort port} or a {@link TopologySegment segment}.
+     * A visitor for accessing the endpoints this edge is connected to. A visitor will be called with one of the
+     * visitSource implementations and one of the visitTarget implementations depending on which type of endpoints this
+     * edge is connected to.
      */
-    interface TopologyEdgeTargetVisitor {
-        default void visitTargetPort(TopologyPort port) {
+    interface EndpointVisitor {
+        default void visitSource(Node node) {
         }
 
-        default void visitTargetSegement(TopologySegment segment) {
+        default void visitSource(TopologyPort port) {
         }
+
+        default void visitSource(TopologySegment segment) {
+        }
+
+        default void visitTarget(Node node) {
+        }
+
+        default void visitTarget(TopologyPort port) {
+        }
+
+        default void visitTarget(TopologySegment segment) {
+        }
+    }
+
+    /**
+     * The set of valid endpoint types that edges support.
+     */
+    enum EndpointType {
+        NODE,
+        PORT,
+        SEGMENT
     }
 }

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableGeoLocation.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableGeoLocation.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.Geolocation;
+
+/**
+ * An immutable implementation of {@link Geolocation} that enforces deep immutability.
+ */
+public final class ImmutableGeoLocation implements Geolocation {
+    private final String address1;
+    private final String address2;
+    private final String city;
+    private final String state;
+    private final String zip;
+    private final String country;
+    private final Double longitude;
+    private final Double latitude;
+
+    private ImmutableGeoLocation(Builder builder) {
+        this.address1 = builder.address1;
+        this.address2 = builder.address2;
+        this.city = builder.city;
+        this.state = builder.state;
+        this.zip = builder.zip;
+        this.country = builder.country;
+        this.longitude = builder.longitude;
+        this.latitude = builder.latitude;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilderFrom(Geolocation fromGeoLocation) {
+        return new Builder(fromGeoLocation);
+    }
+
+    public static final class Builder {
+        private String address1;
+        private String address2;
+        private String city;
+        private String state;
+        private String zip;
+        private String country;
+        private Double longitude;
+        private Double latitude;
+
+        private Builder() {
+        }
+
+        private Builder(Geolocation geolocation) {
+            this.address1 = geolocation.getAddress1();
+            this.address2 = geolocation.getAddress2();
+            this.city = geolocation.getCity();
+            this.state = geolocation.getState();
+            this.zip = geolocation.getZip();
+            this.country = geolocation.getCountry();
+            this.longitude = geolocation.getLongitude();
+            this.latitude = geolocation.getLatitude();
+        }
+
+        public Builder setAddress1(String address1) {
+            this.address1 = address1;
+            return this;
+        }
+
+        public Builder setAddress2(String address2) {
+            this.address2 = address2;
+            return this;
+        }
+
+        public Builder setCity(String city) {
+            this.city = city;
+            return this;
+        }
+
+        public Builder setState(String state) {
+            this.state = state;
+            return this;
+        }
+
+        public Builder setZip(String zip) {
+            this.zip = zip;
+            return this;
+        }
+
+        public Builder setCountry(String country) {
+            this.country = country;
+            return this;
+        }
+
+        public Builder setLongitude(Double longitude) {
+            this.longitude = longitude;
+            return this;
+        }
+
+        public Builder setLatitude(Double latitude) {
+            this.latitude = latitude;
+            return this;
+        }
+
+        public ImmutableGeoLocation build() {
+            return new ImmutableGeoLocation(this);
+        }
+    }
+
+    @Override
+    public String getAddress1() {
+        return address1;
+    }
+
+    @Override
+    public String getAddress2() {
+        return address2;
+    }
+
+    @Override
+    public String getCity() {
+        return city;
+    }
+
+    @Override
+    public String getState() {
+        return state;
+    }
+
+    @Override
+    public String getZip() {
+        return zip;
+    }
+
+    @Override
+    public String getCountry() {
+        return country;
+    }
+
+    @Override
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    @Override
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableGeoLocation that = (ImmutableGeoLocation) o;
+        return Objects.equals(address1, that.address1) &&
+                Objects.equals(address2, that.address2) &&
+                Objects.equals(city, that.city) &&
+                Objects.equals(state, that.state) &&
+                Objects.equals(zip, that.zip) &&
+                Objects.equals(country, that.country) &&
+                Objects.equals(longitude, that.longitude) &&
+                Objects.equals(latitude, that.latitude);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address1, address2, city, state, zip, country, longitude, latitude);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableGeoLocation{" +
+                "address1='" + address1 + '\'' +
+                ", address2='" + address2 + '\'' +
+                ", city='" + city + '\'' +
+                ", state='" + state + '\'' +
+                ", zip='" + zip + '\'' +
+                ", country='" + country + '\'' +
+                ", longitude=" + longitude +
+                ", latitude=" + latitude +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
@@ -29,6 +29,7 @@
 package org.opennms.integration.api.v1.model.immutables;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -67,7 +68,7 @@ public final class ImmutableIpInterface implements IpInterface {
 
         private Builder(IpInterface ipInterface) {
             this.ipAddress = ipInterface.getIpAddress();
-            this.metaData = ipInterface.getMetaData();
+            this.metaData = new ArrayList<>(ipInterface.getMetaData());
         }
 
         public Builder setIpAddress(InetAddress ipAddress) {

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.model.IpInterface;
+import org.opennms.integration.api.v1.model.MetaData;
+
+/**
+ * An immutable implementation of {@link IpInterface} that enforces deep immutability.
+ */
+public final class ImmutableIpInterface implements IpInterface {
+    private final InetAddress ipAddress;
+    private final List<MetaData> metaData;
+
+    private ImmutableIpInterface(Builder builder) {
+        this.ipAddress = builder.ipAddress;
+        this.metaData = builder.metaData == null ? null : copyMetaData(builder.metaData);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilderFrom(IpInterface fromIpInterface) {
+        return new Builder(fromIpInterface);
+    }
+
+    public static final class Builder {
+        private InetAddress ipAddress;
+        private List<MetaData> metaData;
+
+        private Builder() {
+        }
+
+        private Builder(IpInterface ipInterface) {
+            this.ipAddress = ipInterface.getIpAddress();
+            this.metaData = ipInterface.getMetaData();
+        }
+
+        public Builder setIpAddress(InetAddress ipAddress) {
+            this.ipAddress = ipAddress;
+            return this;
+        }
+
+        public Builder setMetaData(List<MetaData> metaData) {
+            this.metaData = metaData;
+            return this;
+        }
+
+        public ImmutableIpInterface build() {
+            return new ImmutableIpInterface(this);
+        }
+    }
+
+    private List<MetaData> copyMetaData(List<MetaData> metaData) {
+        return metaData.stream()
+                .map(md -> {
+                    if (!(md instanceof ImmutableMetaData)) {
+                        return ImmutableMetaData.newBuilderFrom(md).build();
+                    }
+
+                    return md;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public InetAddress getIpAddress() {
+        return ipAddress;
+    }
+
+    @Override
+    public List<MetaData> getMetaData() {
+        return metaData == null ? Collections.emptyList() : Collections.unmodifiableList(metaData);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableIpInterface that = (ImmutableIpInterface) o;
+        return Objects.equals(ipAddress, that.ipAddress) &&
+                Objects.equals(metaData, that.metaData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ipAddress, metaData);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableIpInterface{" +
+                "ipAddress=" + ipAddress +
+                ", metaData=" + metaData +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
@@ -46,7 +46,8 @@ public final class ImmutableIpInterface implements IpInterface {
 
     private ImmutableIpInterface(Builder builder) {
         this.ipAddress = builder.ipAddress;
-        this.metaData = builder.metaData == null ? null : copyMetaData(builder.metaData);
+        this.metaData = builder.metaData == null ? Collections.emptyList() :
+                Collections.unmodifiableList(copyMetaData(builder.metaData));
     }
 
     public static Builder newBuilder() {
@@ -103,7 +104,7 @@ public final class ImmutableIpInterface implements IpInterface {
 
     @Override
     public List<MetaData> getMetaData() {
-        return metaData == null ? Collections.emptyList() : Collections.unmodifiableList(metaData);
+        return metaData;
     }
 
     @Override

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMetaData.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMetaData.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.MetaData;
+
+/**
+ * An immutable implementation of {@link MetaData} that enforces deep immutability.
+ */
+public class ImmutableMetaData implements MetaData {
+    private final String context;
+    private final String key;
+    private final String value;
+
+    private ImmutableMetaData(Builder builder) {
+        this.context = builder.context;
+        this.key = builder.key;
+        this.value = builder.value;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilderFrom(MetaData fromMetaData) {
+        return new Builder(fromMetaData);
+    }
+
+    public static final class Builder {
+        private String context;
+        private String key;
+        private String value;
+
+        private Builder() {
+        }
+        
+        private Builder(MetaData metaData) {
+            this.context = metaData.getContext();
+            this.key = metaData.getKey();
+            this.value = metaData.getValue();
+        }
+
+        public Builder setContext(String context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder setKey(String key) {
+            this.key = key;
+            return this;
+        }
+
+        public Builder setValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public ImmutableMetaData build() {
+            return new ImmutableMetaData(this);
+        }
+    }
+
+    @Override
+    public String getContext() {
+        return context;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableMetaData that = (ImmutableMetaData) o;
+        return Objects.equals(context, that.context) &&
+                Objects.equals(key, that.key) &&
+                Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context, key, value);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableMetaData{" +
+                "context='" + context + '\'' +
+                ", key='" + key + '\'' +
+                ", value='" + value + '\'' +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMetaData.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMetaData.java
@@ -35,7 +35,7 @@ import org.opennms.integration.api.v1.model.MetaData;
 /**
  * An immutable implementation of {@link MetaData} that enforces deep immutability.
  */
-public class ImmutableMetaData implements MetaData {
+public final class ImmutableMetaData implements MetaData {
     private final String context;
     private final String key;
     private final String value;

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
@@ -61,9 +61,12 @@ public final class ImmutableNode implements Node {
         this.label = builder.label;
         this.location = builder.location;
         this.assetRecord = builder.assetRecord;
-        this.ipInterfaces = builder.ipInterfaces == null ? null : copyIpInterfaces(builder.ipInterfaces);
-        this.snmpInterfaces = builder.snmpInterfaces == null ? null : copySnmpInterfaces(builder.snmpInterfaces);
-        this.metaData = builder.metaData == null ? null : copyMetaData(builder.metaData);
+        this.ipInterfaces = builder.ipInterfaces == null ? Collections.emptyList() :
+                Collections.unmodifiableList(copyIpInterfaces(builder.ipInterfaces));
+        this.snmpInterfaces = builder.snmpInterfaces == null ? Collections.emptyList() :
+                Collections.unmodifiableList(copySnmpInterfaces(builder.snmpInterfaces));
+        this.metaData = builder.metaData == null ? Collections.emptyList() :
+                Collections.unmodifiableList(copyMetaData(builder.metaData));
     }
 
     public static Builder newBuilder() {
@@ -247,17 +250,17 @@ public final class ImmutableNode implements Node {
 
     @Override
     public List<IpInterface> getIpInterfaces() {
-        return ipInterfaces == null ? Collections.emptyList() : Collections.unmodifiableList(ipInterfaces);
+        return ipInterfaces;
     }
 
     @Override
     public List<SnmpInterface> getSnmpInterfaces() {
-        return snmpInterfaces == null ? Collections.emptyList() : Collections.unmodifiableList(snmpInterfaces);
+        return snmpInterfaces;
     }
 
     @Override
     public List<MetaData> getMetaData() {
-        return metaData == null ? Collections.emptyList() : Collections.unmodifiableList(metaData);
+        return metaData;
     }
 
     @Override

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
@@ -98,9 +98,9 @@ public final class ImmutableNode implements Node {
             this.label = node.getLabel();
             this.location = node.getLocation();
             this.assetRecord = node.getAssetRecord();
-            this.ipInterfaces = node.getIpInterfaces();
-            this.snmpInterfaces = node.getSnmpInterfaces();
-            this.metaData = node.getMetaData();
+            this.ipInterfaces = new ArrayList<>(node.getIpInterfaces());
+            this.snmpInterfaces = new ArrayList<>(node.getSnmpInterfaces());
+            this.metaData = new ArrayList<>(node.getMetaData());
         }
 
         public Builder setId(int id) {

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
@@ -1,0 +1,299 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.model.IpInterface;
+import org.opennms.integration.api.v1.model.MetaData;
+import org.opennms.integration.api.v1.model.Node;
+import org.opennms.integration.api.v1.model.NodeAssetRecord;
+import org.opennms.integration.api.v1.model.SnmpInterface;
+
+/**
+ * An immutable implementation of {@link Node} that enforces deep immutability.
+ */
+public final class ImmutableNode implements Node {
+    private final int id;
+    private final String foreignSource;
+    private final String foreignId;
+    private final String label;
+    private final String location;
+    private final NodeAssetRecord assetRecord;
+    private final List<IpInterface> ipInterfaces;
+    private final List<SnmpInterface> snmpInterfaces;
+    private final List<MetaData> metaData;
+
+    private ImmutableNode(Builder builder) {
+        this.id = builder.id;
+        this.foreignSource = builder.foreignSource;
+        this.foreignId = builder.foreignId;
+        this.label = builder.label;
+        this.location = builder.location;
+        this.assetRecord = builder.assetRecord;
+        this.ipInterfaces = builder.ipInterfaces == null ? null : copyIpInterfaces(builder.ipInterfaces);
+        this.snmpInterfaces = builder.snmpInterfaces == null ? null : copySnmpInterfaces(builder.snmpInterfaces);
+        this.metaData = builder.metaData == null ? null : copyMetaData(builder.metaData);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilderFrom(Node fromNode) {
+        return new Builder(fromNode);
+    }
+
+    public static final class Builder {
+        private Integer id;
+        private String foreignSource;
+        private String foreignId;
+        private String label;
+        private String location;
+        private NodeAssetRecord assetRecord;
+        private List<IpInterface> ipInterfaces;
+        private List<SnmpInterface> snmpInterfaces;
+        private List<MetaData> metaData;
+
+        private Builder() {
+        }
+
+        private Builder(Node node) {
+            this.id = node.getId();
+            this.foreignSource = node.getForeignSource();
+            this.foreignId = node.getForeignId();
+            this.label = node.getLabel();
+            this.location = node.getLocation();
+            this.assetRecord = node.getAssetRecord();
+            this.ipInterfaces = node.getIpInterfaces();
+            this.snmpInterfaces = node.getSnmpInterfaces();
+            this.metaData = node.getMetaData();
+        }
+
+        public Builder setId(int id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setForeignSource(String foreignSource) {
+            this.foreignSource = foreignSource;
+            return this;
+        }
+
+        public Builder setForeignId(String foreignId) {
+            this.foreignId = foreignId;
+            return this;
+        }
+
+        public Builder setLabel(String label) {
+            this.label = label;
+            return this;
+        }
+
+        public Builder setLocation(String location) {
+            this.location = location;
+            return this;
+        }
+
+        public Builder setAssetRecord(NodeAssetRecord assetRecord) {
+            if (assetRecord != null && !(assetRecord instanceof ImmutableNodeAssetRecord)) {
+                this.assetRecord = ImmutableNodeAssetRecord.newBuilderFrom(assetRecord).build();
+            } else {
+                this.assetRecord = assetRecord;
+            }
+            return this;
+        }
+
+        public Builder setIpInterfaces(List<IpInterface> ipInterfaces) {
+            this.ipInterfaces = ipInterfaces;
+            return this;
+        }
+
+        public Builder addIpInterface(IpInterface ipInterface) {
+            if (ipInterfaces == null) {
+                ipInterfaces = new ArrayList<>();
+            }
+            ipInterfaces.add(ipInterface);
+            return this;
+        }
+
+        public Builder setSnmpInterfaces(List<SnmpInterface> snmpInterfaces) {
+            this.snmpInterfaces = snmpInterfaces;
+            return this;
+        }
+
+        public Builder addSnmpInterface(SnmpInterface snmpInterface) {
+            if (snmpInterfaces == null) {
+                snmpInterfaces = new ArrayList<>();
+            }
+            snmpInterfaces.add(snmpInterface);
+            return this;
+        }
+
+        public Builder setMetaData(List<MetaData> metaData) {
+            this.metaData = metaData;
+            return this;
+        }
+
+        public Builder addMetaData(MetaData metaData) {
+            if (this.metaData == null) {
+                this.metaData = new ArrayList<>();
+            }
+            this.metaData.add(metaData);
+            return this;
+        }
+
+        public ImmutableNode build() {
+            Objects.requireNonNull(id);
+            return new ImmutableNode(this);
+        }
+    }
+
+    private List<IpInterface> copyIpInterfaces(List<IpInterface> ipInterfaces) {
+        return ipInterfaces.stream()
+                .map(ipInterface -> {
+                    if (!(ipInterface instanceof ImmutableIpInterface)) {
+                        return ImmutableIpInterface.newBuilderFrom(ipInterface).build();
+                    }
+
+                    return ipInterface;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<SnmpInterface> copySnmpInterfaces(List<SnmpInterface> snmpInterfaces) {
+        return snmpInterfaces.stream()
+                .map(snmpInterface -> {
+                    if (!(snmpInterface instanceof ImmutableSnmpInterface)) {
+                        return ImmutableSnmpInterface.newBuilderFrom(snmpInterface).build();
+                    }
+
+                    return snmpInterface;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<MetaData> copyMetaData(List<MetaData> metaData) {
+        return metaData.stream()
+                .map(md -> {
+                    if (!(md instanceof ImmutableMetaData)) {
+                        return ImmutableMetaData.newBuilderFrom(md).build();
+                    }
+
+                    return md;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Integer getId() {
+        return id;
+    }
+
+    @Override
+    public String getForeignSource() {
+        return foreignSource;
+    }
+
+    @Override
+    public String getForeignId() {
+        return foreignId;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public String getLocation() {
+        return location;
+    }
+
+    @Override
+    public NodeAssetRecord getAssetRecord() {
+        return assetRecord;
+    }
+
+    @Override
+    public List<IpInterface> getIpInterfaces() {
+        return ipInterfaces == null ? Collections.emptyList() : Collections.unmodifiableList(ipInterfaces);
+    }
+
+    @Override
+    public List<SnmpInterface> getSnmpInterfaces() {
+        return snmpInterfaces == null ? Collections.emptyList() : Collections.unmodifiableList(snmpInterfaces);
+    }
+
+    @Override
+    public List<MetaData> getMetaData() {
+        return metaData == null ? Collections.emptyList() : Collections.unmodifiableList(metaData);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableNode that = (ImmutableNode) o;
+        return id == that.id &&
+                Objects.equals(foreignSource, that.foreignSource) &&
+                Objects.equals(foreignId, that.foreignId) &&
+                Objects.equals(label, that.label) &&
+                Objects.equals(location, that.location) &&
+                Objects.equals(assetRecord, that.assetRecord) &&
+                Objects.equals(ipInterfaces, that.ipInterfaces) &&
+                Objects.equals(snmpInterfaces, that.snmpInterfaces) &&
+                Objects.equals(metaData, that.metaData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, foreignSource, foreignId, label, location, assetRecord, ipInterfaces, snmpInterfaces,
+                metaData);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableNode{" +
+                "id=" + id +
+                ", foreignSource='" + foreignSource + '\'' +
+                ", foreignId='" + foreignId + '\'' +
+                ", label='" + label + '\'' +
+                ", location='" + location + '\'' +
+                ", assetRecord=" + assetRecord +
+                ", ipInterfaces=" + ipInterfaces +
+                ", snmpInterfaces=" + snmpInterfaces +
+                ", metaData=" + metaData +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeAssetRecord.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeAssetRecord.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.Geolocation;
+import org.opennms.integration.api.v1.model.NodeAssetRecord;
+
+/**
+ * An immutable implementation of {@link NodeAssetRecord} that enforces deep immutability.
+ */
+public final class ImmutableNodeAssetRecord implements NodeAssetRecord {
+    private final String vendor;
+    private final String modelNumber;
+    private final String description;
+    private final String assetNumber;
+    private final String operatingSystem;
+    private final String region;
+    private final String division;
+    private final String department;
+    private final String building;
+    private final String floor;
+    private final Geolocation geolocation;
+
+    private ImmutableNodeAssetRecord(Builder builder) {
+        this.vendor = builder.vendor;
+        this.modelNumber = builder.modelNumber;
+        this.description = builder.description;
+        this.assetNumber = builder.assetNumber;
+        this.operatingSystem = builder.operatingSystem;
+        this.region = builder.region;
+        this.division = builder.division;
+        this.department = builder.department;
+        this.building = builder.building;
+        this.floor = builder.floor;
+        this.geolocation = builder.geolocation;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilderFrom(NodeAssetRecord fromNodeAssetRecord) {
+        return new Builder(fromNodeAssetRecord);
+    }
+
+    public static final class Builder {
+        private String vendor;
+        private String modelNumber;
+        private String description;
+        private String assetNumber;
+        private String operatingSystem;
+        private String region;
+        private String division;
+        private String department;
+        private String building;
+        private String floor;
+        private Geolocation geolocation;
+
+        private Builder() {
+        }
+
+        private Builder(NodeAssetRecord nodeAssetRecord) {
+            this.vendor = nodeAssetRecord.getVendor();
+            this.modelNumber = nodeAssetRecord.getModelNumber();
+            this.description = nodeAssetRecord.getDescription();
+            this.assetNumber = nodeAssetRecord.getAssetNumber();
+            this.operatingSystem = nodeAssetRecord.getOperatingSystem();
+            this.region = nodeAssetRecord.getRegion();
+            this.division = nodeAssetRecord.getDivision();
+            this.department = nodeAssetRecord.getDepartment();
+            this.building = nodeAssetRecord.getBuilding();
+            this.floor = nodeAssetRecord.getFloor();
+            this.geolocation = nodeAssetRecord.getGeolocation();
+        }
+
+        public Builder setVendor(String vendor) {
+            this.vendor = vendor;
+            return this;
+        }
+
+        public Builder setModelNumber(String modelNumber) {
+            this.modelNumber = modelNumber;
+            return this;
+        }
+
+        public Builder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder setAssetNumber(String assetNumber) {
+            this.assetNumber = assetNumber;
+            return this;
+        }
+
+        public Builder setOperatingSystem(String operatingSystem) {
+            this.operatingSystem = operatingSystem;
+            return this;
+        }
+
+        public Builder setRegion(String region) {
+            this.region = region;
+            return this;
+        }
+
+        public Builder setDivision(String division) {
+            this.division = division;
+            return this;
+        }
+
+        public Builder setDepartment(String department) {
+            this.department = department;
+            return this;
+        }
+
+        public Builder setBuilding(String building) {
+            this.building = building;
+            return this;
+        }
+
+        public Builder setFloor(String floor) {
+            this.floor = floor;
+            return this;
+        }
+
+        public Builder setGeolocation(Geolocation geolocation) {
+            if (geolocation != null && !(geolocation instanceof ImmutableGeoLocation)) {
+                this.geolocation = ImmutableGeoLocation.newBuilderFrom(geolocation).build();
+            } else {
+                this.geolocation = geolocation;
+            }
+            return this;
+        }
+
+        public ImmutableNodeAssetRecord build() {
+            return new ImmutableNodeAssetRecord(this);
+        }
+    }
+
+    @Override
+    public String getVendor() {
+        return vendor;
+    }
+
+    @Override
+    public String getModelNumber() {
+        return modelNumber;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getAssetNumber() {
+        return assetNumber;
+    }
+
+    @Override
+    public String getOperatingSystem() {
+        return operatingSystem;
+    }
+
+    @Override
+    public String getRegion() {
+        return region;
+    }
+
+    @Override
+    public String getDivision() {
+        return division;
+    }
+
+    @Override
+    public String getDepartment() {
+        return department;
+    }
+
+    @Override
+    public String getBuilding() {
+        return building;
+    }
+
+    @Override
+    public String getFloor() {
+        return floor;
+    }
+
+    @Override
+    public Geolocation getGeolocation() {
+        return geolocation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableNodeAssetRecord that = (ImmutableNodeAssetRecord) o;
+        return Objects.equals(vendor, that.vendor) &&
+                Objects.equals(modelNumber, that.modelNumber) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(assetNumber, that.assetNumber) &&
+                Objects.equals(operatingSystem, that.operatingSystem) &&
+                Objects.equals(region, that.region) &&
+                Objects.equals(division, that.division) &&
+                Objects.equals(department, that.department) &&
+                Objects.equals(building, that.building) &&
+                Objects.equals(floor, that.floor) &&
+                Objects.equals(geolocation, that.geolocation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vendor, modelNumber, description, assetNumber, operatingSystem, region, division,
+                department, building, floor, geolocation);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableNodeAssetRecord{" +
+                "vendor='" + vendor + '\'' +
+                ", modelNumber='" + modelNumber + '\'' +
+                ", description='" + description + '\'' +
+                ", assetNumber='" + assetNumber + '\'' +
+                ", operatingSystem='" + operatingSystem + '\'' +
+                ", region='" + region + '\'' +
+                ", division='" + division + '\'' +
+                ", department='" + department + '\'' +
+                ", building='" + building + '\'' +
+                ", floor='" + floor + '\'' +
+                ", geolocation=" + geolocation +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
@@ -55,7 +55,7 @@ public final class ImmutableNodeCriteria implements NodeCriteria {
         return new Builder(fromNodeCriteria);
     }
 
-    public static class Builder {
+    public static final class Builder {
         private Integer id;
         private String foreignSource;
         private String foreignId;

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
@@ -30,8 +30,12 @@ package org.opennms.integration.api.v1.model.immutables;
 
 import java.util.Objects;
 
+import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.NodeCriteria;
 
+/**
+ * An immutable implementation of {@link NodeCriteria} that enforces deep immutability.
+ */
 public final class ImmutableNodeCriteria implements NodeCriteria {
     private final Integer id;
     private final String foreignSource;
@@ -46,6 +50,10 @@ public final class ImmutableNodeCriteria implements NodeCriteria {
     public static Builder newBuilder() {
         return new Builder();
     }
+    
+    public static Builder newBuilderFrom(NodeCriteria fromNodeCriteria) {
+        return new Builder(fromNodeCriteria);
+    }
 
     public static class Builder {
         private Integer id;
@@ -53,6 +61,12 @@ public final class ImmutableNodeCriteria implements NodeCriteria {
         private String foreignId;
 
         private Builder() {
+        }
+        
+        private Builder(NodeCriteria nodeCriteria) {
+            this.id = nodeCriteria.getId();
+            this.foreignSource = nodeCriteria.getForeignSource();
+            this.foreignId = nodeCriteria.getForeignId();
         }
 
         public Builder setId(Integer id) {

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableSnmpInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableSnmpInterface.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.model.SnmpInterface;
+
+/**
+ * An immutable implementation of {@link SnmpInterface} that enforces deep immutability.
+ */
+public class ImmutableSnmpInterface implements SnmpInterface {
+    private final String ifDescr;
+    private final String ifName;
+    private final Integer ifIndex;
+
+    private ImmutableSnmpInterface(Builder builder) {
+        this.ifDescr = builder.ifDescr;
+        this.ifName = builder.ifName;
+        this.ifIndex = builder.ifIndex;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static Builder newBuilderFrom(SnmpInterface fromSnmpInterface) {
+        return new Builder(fromSnmpInterface);
+    }
+
+    public static final class Builder {
+        private String ifDescr;
+        private String ifName;
+        private Integer ifIndex;
+
+        private Builder() {
+        }
+
+        private Builder(SnmpInterface snmpInterface) {
+            this.ifDescr = snmpInterface.getIfDescr();
+            this.ifName = snmpInterface.getIfName();
+            this.ifIndex = snmpInterface.getIfIndex();
+        }
+
+        public Builder setIfDescr(String ifDescr) {
+            this.ifDescr = ifDescr;
+            return this;
+        }
+
+        public Builder setIfName(String ifName) {
+            this.ifName = ifName;
+            return this;
+        }
+
+        public Builder setIfIndex(Integer ifIndex) {
+            this.ifIndex = ifIndex;
+            return this;
+        }
+
+        public ImmutableSnmpInterface build() {
+            return new ImmutableSnmpInterface(this);
+        }
+    }
+
+    @Override
+    public String getIfDescr() {
+        return ifDescr;
+    }
+
+    @Override
+    public String getIfName() {
+        return ifName;
+    }
+
+    @Override
+    public Integer getIfIndex() {
+        return ifIndex;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableSnmpInterface that = (ImmutableSnmpInterface) o;
+        return Objects.equals(ifDescr, that.ifDescr) &&
+                Objects.equals(ifName, that.ifName) &&
+                Objects.equals(ifIndex, that.ifIndex);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ifDescr, ifName, ifIndex);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableSnmpInterface{" +
+                "ifDescr='" + ifDescr + '\'' +
+                ", ifName='" + ifName + '\'' +
+                ", ifIndex=" + ifIndex +
+                '}';
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableSnmpInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableSnmpInterface.java
@@ -35,7 +35,7 @@ import org.opennms.integration.api.v1.model.SnmpInterface;
 /**
  * An immutable implementation of {@link SnmpInterface} that enforces deep immutability.
  */
-public class ImmutableSnmpInterface implements SnmpInterface {
+public final class ImmutableSnmpInterface implements SnmpInterface {
     private final String ifDescr;
     private final String ifName;
     private final Integer ifIndex;

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
@@ -192,13 +192,13 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
         }
         switch (targetType) {
             case NODE:
-                v.visitTarget((Node) source);
+                v.visitTarget((Node) target);
                 break;
             case PORT:
-                v.visitTarget((TopologyPort) source);
+                v.visitTarget((TopologyPort) target);
                 break;
             case SEGMENT:
-                v.visitTarget((TopologySegment) source);
+                v.visitTarget((TopologySegment) target);
                 break;
             default:
                 throw new IllegalStateException(String.format("Target type '%s' is unsupported", sourceType));

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
@@ -62,7 +62,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
         return new Builder();
     }
 
-    public static class Builder {
+    public static final class Builder {
         private TopologyProtocol protocol;
         private String id;
         private String tooltipText;
@@ -101,7 +101,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
 
         public Builder setSource(TopologyPort source) {
             if (source != null && !(source instanceof ImmutableTopologyPort)) {
-                this.source = ImmutableTopologyPort.newBuilderFrom(Objects.requireNonNull(source)).build();
+                this.source = ImmutableTopologyPort.newBuilderFrom(source).build();
             } else {
                 this.source = source;
             }
@@ -111,7 +111,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
 
         public Builder setSource(TopologySegment source) {
             if (source != null && !(source instanceof ImmutableTopologySegment)) {
-                this.source = ImmutableTopologySegment.newBuilderFrom(Objects.requireNonNull(source)).build();
+                this.source = ImmutableTopologySegment.newBuilderFrom(source).build();
             } else {
                 this.source = source;
             }
@@ -131,7 +131,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
 
         public Builder setTarget(TopologyPort target) {
             if (target != null && !(target instanceof ImmutableTopologyPort)) {
-                this.target = ImmutableTopologyPort.newBuilderFrom(Objects.requireNonNull(target)).build();
+                this.target = ImmutableTopologyPort.newBuilderFrom(target).build();
             } else {
                 this.target = target;
             }
@@ -141,7 +141,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
 
         public Builder setTarget(TopologySegment target) {
             if (target != null && !(target instanceof ImmutableTopologySegment)) {
-                this.target = ImmutableTopologySegment.newBuilderFrom(Objects.requireNonNull(target)).build();
+                this.target = ImmutableTopologySegment.newBuilderFrom(target).build();
             } else {
                 this.target = target;
             }

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
@@ -123,7 +123,7 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
             if (target != null && !(target instanceof ImmutableNode)) {
                 this.target = ImmutableNode.newBuilderFrom(target).build();
             } else {
-                this.target = source;
+                this.target = target;
             }
             this.targetType = EndpointType.NODE;
             return this;

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
@@ -30,26 +30,32 @@ package org.opennms.integration.api.v1.model.immutables;
 
 import java.util.Objects;
 
+import org.opennms.integration.api.v1.model.Node;
 import org.opennms.integration.api.v1.model.TopologyEdge;
 import org.opennms.integration.api.v1.model.TopologyPort;
 import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.model.TopologySegment;
 
+/**
+ * An immutable implementation of {@link TopologyEdge} that enforces deep immutability.
+ */
 public final class ImmutableTopologyEdge implements TopologyEdge {
     private final TopologyProtocol protocol;
     private final String id;
     private final String tooltipText;
-    private final TopologyPort source;
-    private final TopologyPort targetPort;
-    private final TopologySegment targetSegment;
+    private final Object source;
+    private final Object target;
+    private final EndpointType sourceType;
+    private final EndpointType targetType;
 
     private ImmutableTopologyEdge(Builder builder) {
         this.protocol = builder.protocol;
         this.id = builder.id;
         this.tooltipText = builder.tooltipText;
         this.source = builder.source;
-        this.targetPort = builder.targetPort;
-        this.targetSegment = builder.targetSegment;
+        this.sourceType = builder.sourceType;
+        this.target = builder.target;
+        this.targetType = builder.targetType;
     }
 
     public static Builder newBuilder() {
@@ -60,9 +66,10 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
         private TopologyProtocol protocol;
         private String id;
         private String tooltipText;
-        private TopologyPort source;
-        private TopologyPort targetPort;
-        private TopologySegment targetSegment;
+        private Object source;
+        private Object target;
+        private EndpointType sourceType;
+        private EndpointType targetType;
 
         private Builder() {
         }
@@ -82,30 +89,73 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
             return this;
         }
 
+        public Builder setSource(Node source) {
+            if (source != null && !(source instanceof ImmutableNode)) {
+                this.source = ImmutableNode.newBuilderFrom(source).build();
+            } else {
+                this.source = source;
+            }
+            this.sourceType = EndpointType.NODE;
+            return this;
+        }
+
         public Builder setSource(TopologyPort source) {
-            this.source = Objects.requireNonNull(source);
+            if (source != null && !(source instanceof ImmutableTopologyPort)) {
+                this.source = ImmutableTopologyPort.newBuilderFrom(Objects.requireNonNull(source)).build();
+            } else {
+                this.source = source;
+            }
+            this.sourceType = EndpointType.PORT;
             return this;
         }
 
-        public Builder setTargetPort(TopologyPort targetPort) {
-            this.targetPort = targetPort;
+        public Builder setSource(TopologySegment source) {
+            if (source != null && !(source instanceof ImmutableTopologySegment)) {
+                this.source = ImmutableTopologySegment.newBuilderFrom(Objects.requireNonNull(source)).build();
+            } else {
+                this.source = source;
+            }
+            this.sourceType = EndpointType.SEGMENT;
             return this;
         }
 
-        public Builder setTargetSegment(TopologySegment targetSegment) {
-            this.targetSegment = targetSegment;
+        public Builder setTarget(Node target) {
+            if (target != null && !(target instanceof ImmutableNode)) {
+                this.target = ImmutableNode.newBuilderFrom(target).build();
+            } else {
+                this.target = source;
+            }
+            this.targetType = EndpointType.NODE;
+            return this;
+        }
+
+        public Builder setTarget(TopologyPort target) {
+            if (target != null && !(target instanceof ImmutableTopologyPort)) {
+                this.target = ImmutableTopologyPort.newBuilderFrom(Objects.requireNonNull(target)).build();
+            } else {
+                this.target = target;
+            }
+            this.targetType = EndpointType.PORT;
+            return this;
+        }
+
+        public Builder setTarget(TopologySegment target) {
+            if (target != null && !(target instanceof ImmutableTopologySegment)) {
+                this.target = ImmutableTopologySegment.newBuilderFrom(Objects.requireNonNull(target)).build();
+            } else {
+                this.target = target;
+            }
+            this.targetType = EndpointType.SEGMENT;
             return this;
         }
 
         public ImmutableTopologyEdge build() {
             Objects.requireNonNull(id);
             Objects.requireNonNull(protocol);
-            if (targetPort == null && targetSegment == null) {
-                throw new NullPointerException("Edge must have a target");
-            }
-            if (targetPort != null && targetSegment != null) {
-                throw new IllegalStateException("Edge cannot have both a target port and a target segment");
-            }
+            Objects.requireNonNull(source);
+            Objects.requireNonNull(target);
+            Objects.requireNonNull(sourceType);
+            Objects.requireNonNull(targetType);
             return new ImmutableTopologyEdge(this);
         }
     }
@@ -126,16 +176,32 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
     }
 
     @Override
-    public TopologyPort getSource() {
-        return source;
-    }
-
-    @Override
-    public void visitTarget(TopologyEdgeTargetVisitor v) {
-        if (targetPort != null) {
-            v.visitTargetPort(targetPort);
-        } else {
-            v.visitTargetSegement(targetSegment);
+    public void visitEndpoints(EndpointVisitor v) {
+        switch (sourceType) {
+            case NODE:
+                v.visitSource((Node) source);
+                break;
+            case PORT:
+                v.visitSource((TopologyPort) source);
+                break;
+            case SEGMENT:
+                v.visitSource((TopologySegment) source);
+                break;
+            default:
+                throw new IllegalStateException(String.format("Source type '%s' is unsupported", sourceType));
+        }
+        switch (targetType) {
+            case NODE:
+                v.visitTarget((Node) source);
+                break;
+            case PORT:
+                v.visitTarget((TopologyPort) source);
+                break;
+            case SEGMENT:
+                v.visitTarget((TopologySegment) source);
+                break;
+            default:
+                throw new IllegalStateException(String.format("Target type '%s' is unsupported", sourceType));
         }
     }
 
@@ -144,28 +210,30 @@ public final class ImmutableTopologyEdge implements TopologyEdge {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ImmutableTopologyEdge that = (ImmutableTopologyEdge) o;
-        return Objects.equals(protocol, that.protocol) &&
+        return protocol == that.protocol &&
                 Objects.equals(id, that.id) &&
                 Objects.equals(tooltipText, that.tooltipText) &&
                 Objects.equals(source, that.source) &&
-                Objects.equals(targetPort, that.targetPort) &&
-                Objects.equals(targetSegment, that.targetSegment);
+                Objects.equals(target, that.target) &&
+                sourceType == that.sourceType &&
+                targetType == that.targetType;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(protocol, id, tooltipText, source, targetPort, targetSegment);
+        return Objects.hash(protocol, id, tooltipText, source, target, sourceType, targetType);
     }
 
     @Override
     public String toString() {
         return "ImmutableTopologyEdge{" +
-                "protocol='" + protocol + '\'' +
+                "protocol=" + protocol +
                 ", id='" + id + '\'' +
                 ", tooltipText='" + tooltipText + '\'' +
                 ", source=" + source +
-                ", targetPort=" + targetPort +
-                ", targetSegment=" + targetSegment +
+                ", target=" + target +
+                ", sourceType=" + sourceType +
+                ", targetType=" + targetType +
                 '}';
     }
 }

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
@@ -61,7 +61,7 @@ public final class ImmutableTopologyPort implements TopologyPort {
         return new Builder(fromTopologyPort);
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String id;
         private String tooltipText;
         private Integer ifIndex;

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
@@ -33,6 +33,9 @@ import java.util.Objects;
 import org.opennms.integration.api.v1.model.NodeCriteria;
 import org.opennms.integration.api.v1.model.TopologyPort;
 
+/**
+ * An immutable implementation of {@link TopologyPort} that enforces deep immutability.
+ */
 public final class ImmutableTopologyPort implements TopologyPort {
     private final String id;
     private final String tooltipText;
@@ -54,6 +57,10 @@ public final class ImmutableTopologyPort implements TopologyPort {
         return new Builder();
     }
 
+    public static Builder newBuilderFrom(TopologyPort fromTopologyPort) {
+        return new Builder(fromTopologyPort);
+    }
+
     public static class Builder {
         private String id;
         private String tooltipText;
@@ -63,6 +70,15 @@ public final class ImmutableTopologyPort implements TopologyPort {
         private NodeCriteria nodeCriteria;
 
         private Builder() {
+        }
+
+        private Builder(TopologyPort topologyPort) {
+            this.id = topologyPort.getId();
+            this.tooltipText = topologyPort.getTooltipText();
+            this.ifIndex = topologyPort.getIfIndex();
+            this.ifName = topologyPort.getIfName();
+            this.ifAddress = topologyPort.getIfAddress();
+            this.nodeCriteria = topologyPort.getNodeCriteria();
         }
 
         public Builder setId(String id) {
@@ -91,7 +107,11 @@ public final class ImmutableTopologyPort implements TopologyPort {
         }
 
         public Builder setNodeCriteria(NodeCriteria nodeCriteria) {
-            this.nodeCriteria = nodeCriteria;
+            if (nodeCriteria != null && !(nodeCriteria instanceof ImmutableNodeCriteria)) {
+                this.nodeCriteria = ImmutableNodeCriteria.newBuilderFrom(nodeCriteria).build();
+            } else {
+                this.nodeCriteria = nodeCriteria;
+            }
             return this;
         }
 

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
@@ -55,7 +55,7 @@ public final class ImmutableTopologySegment implements TopologySegment {
         return new Builder(fromSegment);
     }
 
-    public static class Builder {
+    public static final class Builder {
         private String id;
         private String tooltipText;
         private TopologyProtocol protocol;

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
@@ -33,6 +33,9 @@ import java.util.Objects;
 import org.opennms.integration.api.v1.model.TopologyProtocol;
 import org.opennms.integration.api.v1.model.TopologySegment;
 
+/**
+ * An immutable implementation of {@link TopologySegment} that enforces deep immutability.
+ */
 public final class ImmutableTopologySegment implements TopologySegment {
     private final String id;
     private final TopologyProtocol protocol;
@@ -48,12 +51,22 @@ public final class ImmutableTopologySegment implements TopologySegment {
         return new Builder();
     }
 
+    public static Builder newBuilderFrom(TopologySegment fromSegment) {
+        return new Builder(fromSegment);
+    }
+
     public static class Builder {
         private String id;
         private String tooltipText;
         private TopologyProtocol protocol;
 
         private Builder() {
+        }
+
+        private Builder(TopologySegment segment) {
+            this.id = segment.getId();
+            this.tooltipText = segment.getTooltipText();
+            this.protocol = segment.getProtocol();
         }
 
         public Builder setId(String id) {


### PR DESCRIPTION
Discovered that there are valid cases where edges are between two segments or between two nodes with no ports involved. These changes are to support that.

Since I added nodes as a valid endpoint for edges, I made immutable impls for all the node related classes as well.

Jira: https://issues.opennms.org/browse/OCE-55