### PR TITLE
OIA-14: Extend Threshold configuration

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Basethresholddef.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Basethresholddef.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @since 1.0.0
+ */
+public interface Basethresholddef {
+
+    Boolean getRelaxed();
+
+    Optional<String> getDescription();
+
+    ThresholdType getType();
+
+    String getDsType();
+
+    Double getValue();
+
+    Double getRearm();
+
+    Integer getTrigger();
+
+    Optional<String> getDsLabel();
+
+    Optional<String> getTriggeredUEI();
+
+    Optional<String> getRearmedUEI();
+
+    FilterOperator getFilterOperator();
+
+    List<ResourceFilter> getResourceFilters();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ExcludeRange.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ExcludeRange.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * @since 1.0.0
+ */
+public interface ExcludeRange {
+
+    String getBegin();
+
+    String getEnd();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Expression.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Expression.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * Threhsolding expression.
+ *
+ * @since 1.0.0
+ */
+public interface Expression extends Basethresholddef {
+
+    String getExpression();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Filter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Filter.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.Optional;
+
+/**
+ * @since 1.0.0
+ */
+public interface Filter {
+
+    Optional<String> getContent();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/FilterOperator.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/FilterOperator.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * @since 1.0.0
+ */
+public enum FilterOperator {
+
+    AND,
+
+    OR;
+
+    public String getEnumName() {
+        return this.toString().toLowerCase();
+    }
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/GroupDefinition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/GroupDefinition.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.List;
+
+/**
+ * A thresholding group definition.
+ *
+ * @since 1.0.0
+ */
+public interface GroupDefinition {
+
+    String getName();
+
+    String getRrdRepository();
+
+    List<Threshold> getThresholds();
+
+    List<Expression> getExpressions();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/IncludeRange.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/IncludeRange.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * @since 1.0.0
+ */
+public interface IncludeRange {
+
+    String getBegin();
+
+    String getEnd();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/PackageDefinition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/PackageDefinition.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.List;
+
+/**
+ * Thresholding package definition.
+ *
+ * @since 1.0.0
+ */
+public interface PackageDefinition {
+
+    String getName();
+    
+    Filter getFilter();
+
+    List<String> getSpecifics();
+
+    List<IncludeRange> getIncludeRanges();
+
+    List<ExcludeRange> getExcludeRanges();
+
+    List<String> getIncludeUrls();
+
+    List<Service> getServices();
+
+    List<String> getOutageCalendars();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Parameter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Parameter.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * @since 1.0.0
+ */
+public interface Parameter {
+
+    String getKey();
+
+    String getValue();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ResourceFilter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ResourceFilter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.Optional;
+
+/**
+ * @since 1.0.0
+ */
+public interface ResourceFilter {
+
+    Optional<String> getContent();
+
+    String getField();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Service.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Service.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @since 1.0.0
+ */
+public interface Service {
+
+    String getName();
+
+    Long getInterval();
+
+    Boolean getUserDefined();
+
+    Optional<ServiceStatus> getStatus();
+
+    List<Parameter> getParameters();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ServiceStatus.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ServiceStatus.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * @since 1.0.0
+ */
+public enum ServiceStatus {
+    ON,
+    OFF
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThreshdConfigurationExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThreshdConfigurationExtension.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.List;
+
+import org.opennms.integration.api.v1.annotations.Exposable;
+
+/**
+ * Used to expose thresholding package and thresholder definitions.
+ *
+ * @since 1.0.0
+ */
+@Exposable
+public interface ThreshdConfigurationExtension {
+
+    Integer getThreads();
+
+    List<PackageDefinition> getPackages();
+
+    List<ThresholderDefinition> getThresholders();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Threshold.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Threshold.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * @since 1.0.0
+ */
+public interface Threshold extends Basethresholddef {
+
+    String getDsName();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdType.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdType.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+/**
+ * @since 1.0.0
+ */
+public enum ThresholdType {
+
+    HIGH("high"),
+
+    LOW("low"),
+
+    RELATIVE_CHANGE("relativeChange"),
+
+    ABSOLUTE_CHANGE("absoluteChange"),
+
+    REARMING_ABSOLUTE_CHANGE("rearmingAbsoluteChange");
+
+    private String m_enumName;
+
+    ThresholdType(final String enumName) {
+        m_enumName = enumName;
+    }
+
+    public String getEnumName() {
+        return m_enumName;
+    }
+
+    public static ThresholdType forName(final String name) {
+        for (final ThresholdType type : ThresholdType.values()) {
+            if (name.equalsIgnoreCase(type.getEnumName())) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholderDefinition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholderDefinition.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.List;
+
+/**
+ * @since 1.0.0
+ */
+public interface ThresholderDefinition {
+
+    String getService();
+
+    String getClassName();
+
+    List<Parameter> getParameters();
+
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdingConfigExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdingConfigExtension.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.config.thresholding;
+
+import java.util.List;
+
+import org.opennms.integration.api.v1.annotations.Exposable;
+
+/**
+ * Used to expose thresholding group definitions.
+ *
+ * @since 1.0.0
+ */
+@Exposable
+public interface ThresholdingConfigExtension {
+
+    List<GroupDefinition> getGroupDefinitions();
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathThreshdConfigurationLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathThreshdConfigurationLoader.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.config.thresholding.ExcludeRange;
+import org.opennms.integration.api.v1.config.thresholding.Filter;
+import org.opennms.integration.api.v1.config.thresholding.IncludeRange;
+import org.opennms.integration.api.v1.config.thresholding.PackageDefinition;
+import org.opennms.integration.api.v1.config.thresholding.Parameter;
+import org.opennms.integration.api.v1.config.thresholding.Service;
+import org.opennms.integration.api.v1.config.thresholding.ServiceStatus;
+import org.opennms.integration.api.v1.config.thresholding.ThresholderDefinition;
+import org.opennms.integration.api.xml.schema.thresholding.Package;
+import org.opennms.integration.api.xml.schema.thresholding.ThreshdConfiguration;
+import org.opennms.integration.api.xml.schema.thresholding.Thresholder;
+
+/**
+ * Used to load XML threshd configuration from the class-path.
+ *
+ * @author mbrooks
+ * @since 1.0.0
+ */
+public class ClasspathThreshdConfigurationLoader extends ClasspathXmlLoader<ThreshdConfiguration> {
+    public ClasspathThreshdConfigurationLoader(Class<?> clazz, String... fileNames) {
+        super(clazz, ThreshdConfiguration.class, "thresholding", fileNames);
+    }
+
+    public Integer getThreads() {
+        // Return only the largest of the threads elements
+        return getObjects()
+                .stream()
+                .map(ThreshdConfiguration::getThreads)
+                .filter(Objects::nonNull)
+                .max(Integer::compareTo)
+                .orElse(null);
+    }
+
+    public List<PackageDefinition> getPackages() {
+        return getObjects().stream()
+                .flatMap(tc -> tc.getPackages().stream())
+                .map(ClasspathThreshdConfigurationLoader::toPackageDefinition)
+                .collect(Collectors.toList());
+    }
+
+    public List<ThresholderDefinition> getThresholders() {
+        return getObjects().stream()
+                .flatMap(tc -> tc.getThresholders().stream())
+                .map(ClasspathThreshdConfigurationLoader::toThresholderDefinition)
+                .collect(Collectors.toList());
+    }
+
+    private static PackageDefinition toPackageDefinition(Package packageToConvert) {
+        return new PackageDefinition() {
+            private final Filter filter = toFilter(packageToConvert.getFilter());
+            private final List<String> specifics = Collections.unmodifiableList(packageToConvert.getSpecifics());
+            private final List<IncludeRange> includeRanges =
+                    Collections.unmodifiableList(packageToConvert.getIncludeRanges()
+                            .stream()
+                            .map(ClasspathThreshdConfigurationLoader::toIncludeRange)
+                            .collect(Collectors.toList()));
+            private final List<ExcludeRange> excludeRanges =
+                    Collections.unmodifiableList(packageToConvert.getExcludeRanges()
+                            .stream()
+                            .map(ClasspathThreshdConfigurationLoader::toExcludeRange)
+                            .collect(Collectors.toList()));
+            private final List<String> includedUrls = Collections.unmodifiableList(packageToConvert.getIncludeUrls());
+            private final List<String> outageCalendars =
+                    Collections.unmodifiableList(packageToConvert.getOutageCalendars());
+            private final List<Service> services = Collections.unmodifiableList(packageToConvert.getServices()
+                    .stream()
+                    .map(ClasspathThreshdConfigurationLoader::toService)
+                    .collect(Collectors.toList()));
+
+            @Override
+            public String getName() {
+                return packageToConvert.getName();
+            }
+
+            @Override
+            public Filter getFilter() {
+                return filter;
+            }
+
+            @Override
+            public List<String> getSpecifics() {
+                return specifics;
+            }
+
+            @Override
+            public List<IncludeRange> getIncludeRanges() {
+                return includeRanges;
+            }
+
+            @Override
+            public List<ExcludeRange> getExcludeRanges() {
+                return excludeRanges;
+            }
+
+            @Override
+            public List<String> getIncludeUrls() {
+                return includedUrls;
+            }
+
+            @Override
+            public List<Service> getServices() {
+                return services;
+            }
+
+            @Override
+            public List<String> getOutageCalendars() {
+                return outageCalendars;
+            }
+        };
+    }
+
+    private static ThresholderDefinition toThresholderDefinition(Thresholder thresholder) {
+        return new ThresholderDefinition() {
+            private final List<Parameter> parameters = Collections.unmodifiableList(thresholder.getParameters()
+                    .stream()
+                    .map(ClasspathThreshdConfigurationLoader::toParameter)
+                    .collect(Collectors.toList()));
+
+            @Override
+            public String getService() {
+                return thresholder.getService();
+            }
+
+            @Override
+            public String getClassName() {
+                return thresholder.getClassName();
+            }
+
+            @Override
+            public List<Parameter> getParameters() {
+                return parameters;
+            }
+        };
+    }
+
+    private static Filter toFilter(org.opennms.integration.api.xml.schema.thresholding.Filter filter) {
+        return new Filter() {
+            @Override
+            public Optional<String> getContent() {
+                return filter.getContent();
+            }
+        };
+    }
+
+    private static IncludeRange toIncludeRange(org.opennms.integration.api.xml.schema.thresholding.IncludeRange includeRange) {
+        return new IncludeRange() {
+            @Override
+            public String getBegin() {
+                return includeRange.getBegin();
+            }
+
+            @Override
+            public String getEnd() {
+                return includeRange.getEnd();
+            }
+        };
+    }
+
+    private static ExcludeRange toExcludeRange(org.opennms.integration.api.xml.schema.thresholding.ExcludeRange excludeRange) {
+        return new ExcludeRange() {
+            @Override
+            public String getBegin() {
+                return excludeRange.getBegin();
+            }
+
+            @Override
+            public String getEnd() {
+                return excludeRange.getEnd();
+            }
+        };
+    }
+
+    private static Service toService(org.opennms.integration.api.xml.schema.thresholding.Service service) {
+        return new Service() {
+            private final List<Parameter> parameters = Collections.unmodifiableList(service.getParameters()
+                    .stream()
+                    .map(ClasspathThreshdConfigurationLoader::toParameter)
+                    .collect(Collectors.toList()));
+
+            @Override
+            public String getName() {
+                return service.getName();
+            }
+
+            @Override
+            public Long getInterval() {
+                return service.getInterval();
+            }
+
+            @Override
+            public Boolean getUserDefined() {
+                return service.getUserDefined();
+            }
+
+            @Override
+            public Optional<ServiceStatus> getStatus() {
+                return service.getStatus().map(s -> ServiceStatus.valueOf(s.name()));
+            }
+
+            @Override
+            public List<Parameter> getParameters() {
+                return parameters;
+            }
+        };
+    }
+
+    private static Parameter toParameter(org.opennms.integration.api.xml.schema.thresholding.Parameter parameter) {
+        return new Parameter() {
+            @Override
+            public String getKey() {
+                return parameter.getKey();
+            }
+
+            @Override
+            public String getValue() {
+                return parameter.getValue();
+            }
+        };
+    }
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathThresholdingConfigLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathThresholdingConfigLoader.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.config.thresholding.Basethresholddef;
+import org.opennms.integration.api.v1.config.thresholding.Expression;
+import org.opennms.integration.api.v1.config.thresholding.FilterOperator;
+import org.opennms.integration.api.v1.config.thresholding.GroupDefinition;
+import org.opennms.integration.api.v1.config.thresholding.ResourceFilter;
+import org.opennms.integration.api.v1.config.thresholding.Threshold;
+import org.opennms.integration.api.v1.config.thresholding.ThresholdType;
+import org.opennms.integration.api.xml.schema.thresholding.Group;
+import org.opennms.integration.api.xml.schema.thresholding.ThresholdingConfig;
+
+/**
+ * Used to load XML thresholding configuration from the class-path.
+ *
+ * @author mbrooks
+ * @since 1.0.0
+ */
+public class ClasspathThresholdingConfigLoader extends ClasspathXmlLoader<ThresholdingConfig> {
+    public ClasspathThresholdingConfigLoader(Class<?> clazz, String... fileNames) {
+        super(clazz, ThresholdingConfig.class, "thresholding", fileNames);
+    }
+
+    public List<GroupDefinition> getGroupDefinitions() {
+        return getObjects().stream()
+                .flatMap(tc -> tc.getGroups().stream())
+                .map(ClasspathThresholdingConfigLoader::toGroupDefinition)
+                .collect(Collectors.toList());
+    }
+
+    private static GroupDefinition toGroupDefinition(Group group) {
+        return new GroupDefinition() {
+            private final String name = group.getName();
+            private final String rrdRepository = group.getRrdRepository();
+            private final List<Threshold> thresholds = Collections.unmodifiableList(group.getThresholds()
+                    .stream()
+                    .map(ThresholdImpl::new)
+                    .collect(Collectors.toList()));
+            private final List<Expression> expressions = Collections.unmodifiableList(group.getExpressions()
+                    .stream()
+                    .map(ExpressionImpl::new)
+                    .collect(Collectors.toList()));
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getRrdRepository() {
+                return rrdRepository;
+            }
+
+            @Override
+            public List<Threshold> getThresholds() {
+                return thresholds;
+            }
+
+            @Override
+            public List<Expression> getExpressions() {
+                return expressions;
+            }
+        };
+    }
+
+    private static class BasethresholddefImpl implements Basethresholddef {
+        private final org.opennms.integration.api.xml.schema.thresholding.Basethresholddef basethresholddef;
+        private final List<ResourceFilter> resourceFilters;
+
+        BasethresholddefImpl(org.opennms.integration.api.xml.schema.thresholding.Basethresholddef basethresholddef) {
+            this.basethresholddef = Objects.requireNonNull(basethresholddef);
+            resourceFilters = Collections.unmodifiableList(basethresholddef.getResourceFilters()
+                    .stream()
+                    .map(ClasspathThresholdingConfigLoader::toResourceFilter)
+                    .collect(Collectors.toList()));
+        }
+
+        @Override
+        public Boolean getRelaxed() {
+            return basethresholddef.getRelaxed();
+        }
+
+        @Override
+        public Optional<String> getDescription() {
+            return basethresholddef.getDescription();
+        }
+
+        @Override
+        public ThresholdType getType() {
+            return ThresholdType.forName(basethresholddef.getType().getEnumName());
+        }
+
+        @Override
+        public String getDsType() {
+            return basethresholddef.getDsType();
+        }
+
+        @Override
+        public Double getValue() {
+            return basethresholddef.getValue();
+        }
+
+        @Override
+        public Double getRearm() {
+            return basethresholddef.getRearm();
+        }
+
+        @Override
+        public Integer getTrigger() {
+            return basethresholddef.getTrigger();
+        }
+
+        @Override
+        public Optional<String> getDsLabel() {
+            return basethresholddef.getDsLabel();
+        }
+
+        @Override
+        public Optional<String> getTriggeredUEI() {
+            return basethresholddef.getTriggeredUEI();
+        }
+
+        @Override
+        public Optional<String> getRearmedUEI() {
+            return basethresholddef.getRearmedUEI();
+        }
+
+        @Override
+        public FilterOperator getFilterOperator() {
+            return FilterOperator.valueOf(basethresholddef.getFilterOperator().name());
+        }
+
+        @Override
+        public List<ResourceFilter> getResourceFilters() {
+            return resourceFilters;
+        }
+    }
+
+    private static class ThresholdImpl extends BasethresholddefImpl implements Threshold {
+        private final String dsName;
+
+        ThresholdImpl(org.opennms.integration.api.xml.schema.thresholding.Threshold threshold) {
+            super(Objects.requireNonNull(threshold));
+            dsName = threshold.getDsName();
+        }
+
+        @Override
+        public String getDsName() {
+            return dsName;
+        }
+    }
+
+    private static class ExpressionImpl extends BasethresholddefImpl implements Expression {
+        private final String expression;
+
+        ExpressionImpl(org.opennms.integration.api.xml.schema.thresholding.Expression expression) {
+            super(Objects.requireNonNull(expression));
+            this.expression = expression.getExpression();
+        }
+
+        @Override
+        public String getExpression() {
+            return expression;
+        }
+    }
+
+    private static ResourceFilter toResourceFilter(org.opennms.integration.api.xml.schema.thresholding.ResourceFilter resourceFilter) {
+        return new ResourceFilter() {
+            @Override
+            public Optional<String> getContent() {
+                return resourceFilter.getContent();
+            }
+
+            @Override
+            public String getField() {
+                return resourceFilter.getField();
+            }
+        };
+    }
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Basethresholddef.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Basethresholddef.java
@@ -1,0 +1,314 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+@XmlRootElement(name = "basethresholddef")
+@XmlAccessorType(XmlAccessType.FIELD)
+public abstract class Basethresholddef implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    private static final FilterOperator DEFAULT_FILTER_OPERATOR = FilterOperator.OR;
+
+    /**
+     * An optional flag to tell the threshold processor to evaluate the expression
+     * even if there are unknown values.
+     *  This can be useful when processing expressions with conditionals. Default: false
+     */
+    @XmlAttribute(name = "relaxed")
+    private Boolean m_relaxed;
+
+    /**
+     * An optional description for the threshold, to help identify what is their
+     * purpose.
+     */
+    @XmlAttribute(name = "description")
+    private String m_description;
+
+    /**
+     * Threshold type. "high" to trigger if the value exceeds the threshold,
+     *  "low" to trigger if the value drops below the threshold,
+     *  "relativeChange" to trigger if the value changes more than the proportion
+     * represented by the threshold, or
+     *  "absoluteChange" to trigger if the value changes by more than the
+     * threshold value
+     */
+    @XmlAttribute(name = "type", required = true)
+    private ThresholdType m_type;
+
+    /**
+     * RRD datasource type. "node" indicates a node level datasource.
+     *  "if" indicates an interface level datasource.
+     */
+    @XmlAttribute(name = "ds-type", required = true)
+    private String m_dsType;
+
+    /**
+     * Threshold value. If the datasource value rises above this
+     *  value, in the case of a "high" threshold, or drops below this
+     *  value, in the case of a "low" threshold the threshold is
+     *  considered to have been exceeded and the exceeded count will
+     *  be incremented. Any time that the datasource value drops below
+     *  this value, in the case of a "high" threshold, or rises above
+     *  this value, in the case of a "low" threshold the exceeded
+     *  count is reset back to zero. Whenever the exceeded count
+     *  reaches the trigger value then a threshold event is generated.
+     */
+    @XmlAttribute(name = "value", required = true)
+    private Double m_value;
+
+    /**
+     * Rearm value. Identifies the value that the datasource must
+     *  fall below, in the case of a "high" threshold or rise above,
+     *  in the case of a "low" threshold, before the threshold will
+     *  rearm, and once again be eligible to generate an event.
+     */
+    @XmlAttribute(name = "rearm", required = true)
+    private Double m_rearm;
+
+    /**
+     * Trigger value. Identifies the number of consecutive polls that
+     *  the datasource value must exceed the defined threshold value
+     *  before a threshold event is generated.
+     */
+    @XmlAttribute(name = "trigger", required = true)
+    private Integer m_trigger;
+
+    /**
+     * Value to retrieve from strings.properties to label this
+     *  datasource.
+     */
+    @XmlAttribute(name = "ds-label")
+    private String m_dsLabel;
+
+    /**
+     * The UEI to send when this threshold is triggered. If not
+     *  specified, defaults to standard threshold UEIs
+     */
+    @XmlAttribute(name = "triggeredUEI")
+    private String m_triggeredUEI;
+
+    /**
+     * The UEI to send when this threshold is re-armed. If not
+     *  specified, defaults to standard threshold UEIs
+     */
+    @XmlAttribute(name = "rearmedUEI")
+    private String m_rearmedUEI;
+
+    /**
+     * The operator to be used when applying filters. The
+     *  default is "or". If you want to match all filters,
+     *  you should specify "and";
+     */
+    @XmlAttribute(name = "filterOperator")
+    @XmlJavaTypeAdapter(FilterOperatorAdapter.class)
+    private FilterOperator m_filterOperator;
+
+    /**
+     * The filter used to select the ds by a string
+     */
+    @XmlElement(name = "resource-filter")
+    private List<ResourceFilter> m_resourceFilters = new ArrayList<>();
+
+    public Basethresholddef() { }
+
+    public Boolean getRelaxed() {
+        return m_relaxed != null ? m_relaxed : Boolean.FALSE;
+    }
+
+    public void setRelaxed(final Boolean relaxed) {
+        m_relaxed = relaxed;
+    }
+
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(m_description);
+    }
+
+    public void setDescription(final String description) {
+        m_description = ConfigUtils.normalizeAndTrimString(description);
+    }
+
+    public ThresholdType getType() {
+        return m_type;
+    }
+
+    public void setType(final ThresholdType type) {
+        m_type = ConfigUtils.assertNotNull(type, "type");
+    }
+
+    public String getDsType() {
+        return m_dsType;
+    }
+
+    public void setDsType(final String dsType) {
+        m_dsType = ConfigUtils.assertNotEmpty(dsType, "ds-type");
+    }
+
+    public Double getValue() {
+        return m_value;
+    }
+
+    public void setValue(final Double value) {
+        m_value = ConfigUtils.assertNotNull(value, "value");
+    }
+
+    public Double getRearm() {
+        return m_rearm;
+    }
+
+    public void setRearm(final Double rearm) {
+        m_rearm = ConfigUtils.assertNotNull(rearm, "rearm");
+    }
+
+    public Integer getTrigger() {
+        return m_trigger;
+    }
+
+    public void setTrigger(final Integer trigger) {
+        m_trigger = ConfigUtils.assertMinimumInclusive(trigger, 1, "trigger");
+    }
+
+    public Optional<String> getDsLabel() {
+        return Optional.ofNullable(m_dsLabel);
+    }
+
+    public void setDsLabel(final String dsLabel) {
+        m_dsLabel = ConfigUtils.normalizeString(dsLabel);
+    }
+
+    public Optional<String> getTriggeredUEI() {
+        return Optional.ofNullable(m_triggeredUEI);
+    }
+
+    public void setTriggeredUEI(final String triggeredUEI) {
+        m_triggeredUEI = ConfigUtils.normalizeString(triggeredUEI);
+    }
+
+    public Optional<String> getRearmedUEI() {
+        return Optional.ofNullable(m_rearmedUEI);
+    }
+
+    public void setRearmedUEI(final String rearmedUEI) {
+        m_rearmedUEI = ConfigUtils.normalizeString(rearmedUEI);
+    }
+
+    public FilterOperator getFilterOperator() {
+        return m_filterOperator != null ? m_filterOperator : DEFAULT_FILTER_OPERATOR;
+    }
+
+    public void setFilterOperator(final FilterOperator filterOperator) {
+        m_filterOperator = filterOperator;
+    }
+
+    public List<ResourceFilter> getResourceFilters() {
+        return m_resourceFilters;
+    }
+
+    public void setResourceFilters(final List<ResourceFilter> resourceFilters) {
+        if (resourceFilters == m_resourceFilters) return;
+        m_resourceFilters.clear();
+        if (resourceFilters != null) m_resourceFilters.addAll(resourceFilters);
+    }
+
+    /**
+     *
+     *
+     * @param vResourceFilter
+     * @throws IndexOutOfBoundsException if the index given is outside
+     * the bounds of the collection
+     */
+    public void addResourceFilter(final ResourceFilter vResourceFilter) throws IndexOutOfBoundsException {
+        m_resourceFilters.add(vResourceFilter);
+    }
+
+    public boolean removeResourceFilter(final ResourceFilter resourceFilter) {
+        return m_resourceFilters.remove(resourceFilter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_relaxed,
+                m_description,
+                m_type,
+                m_dsType,
+                m_value,
+                m_rearm,
+                m_trigger,
+                m_dsLabel,
+                m_triggeredUEI,
+                m_rearmedUEI,
+                m_filterOperator,
+                m_resourceFilters);
+    }
+
+    /**
+     * Overrides the Object.equals method.
+     *
+     * @param obj
+     * @return true if the objects are equal.
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof Basethresholddef) {
+            final Basethresholddef that = (Basethresholddef)obj;
+            return Objects.equals(this.m_relaxed, that.m_relaxed)
+                    && Objects.equals(this.m_description, that.m_description)
+                    && Objects.equals(this.m_type, that.m_type)
+                    && Objects.equals(this.m_dsType, that.m_dsType)
+                    && Objects.equals(this.m_value, that.m_value)
+                    && Objects.equals(this.m_rearm, that.m_rearm)
+                    && Objects.equals(this.m_trigger, that.m_trigger)
+                    && Objects.equals(this.m_dsLabel, that.m_dsLabel)
+                    && Objects.equals(this.m_triggeredUEI, that.m_triggeredUEI)
+                    && Objects.equals(this.m_rearmedUEI, that.m_rearmedUEI)
+                    && Objects.equals(this.m_filterOperator, that.m_filterOperator)
+                    && Objects.equals(this.m_resourceFilters, that.m_resourceFilters);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ExcludeRange.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ExcludeRange.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Range of addresses to be excluded from this
+ *  package
+ */
+@XmlRootElement(name = "exclude-range")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ExcludeRange implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Starting address of the range
+     */
+    @XmlAttribute(name = "begin", required = true)
+    private String m_begin;
+
+    /**
+     * Ending address of the range
+     */
+    @XmlAttribute(name = "end", required = true)
+    private String m_end;
+
+    public ExcludeRange() {
+    }
+
+    public String getBegin() {
+        return m_begin;
+    }
+
+    public void setBegin(final String begin) {
+        m_begin = ConfigUtils.assertNotEmpty(begin, "begin");
+    }
+
+    public String getEnd() {
+        return m_end;
+    }
+
+    public void setEnd(final String end) {
+        m_end = ConfigUtils.assertNotEmpty(end, "end");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_begin, m_end);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof ExcludeRange) {
+            final ExcludeRange that = (ExcludeRange)obj;
+            return Objects.equals(this.m_begin, that.m_begin)
+                    && Objects.equals(this.m_end, that.m_end);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Expression.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Expression.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Threshold definition
+ */
+@XmlRootElement(name = "expression")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Expression extends Basethresholddef  implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * An expression of Datasource names and constants to be
+     *  evaluate
+     *
+     */
+    @XmlAttribute(name = "expression", required = true)
+    private String m_expression;
+
+    public Expression() {
+    }
+
+    public String getExpression() {
+        return m_expression;
+    }
+
+    public void setExpression(final String expression) {
+        m_expression = ConfigUtils.assertNotEmpty(expression, "expression");
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + Objects.hash(m_expression);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (super.equals(obj)==false) {
+            return false;
+        }
+
+        if (obj instanceof Expression) {
+            final Expression that = (Expression)obj;
+            return Objects.equals(this.m_expression, that.m_expression);
+        }
+        return false;
+    }
+
+}
+

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Filter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Filter.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * A rule which addresses belonging to this package must
+ *  pass. This package is applied only to addresses that pass this
+ *  filter.
+ */
+@XmlRootElement(name = "filter")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Filter implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * internal content storage
+     */
+    @XmlValue
+    private String m_content;
+
+    public Filter() { }
+
+    public Optional<String> getContent() {
+        return Optional.ofNullable(m_content);
+    }
+
+    public void setContent(final String content) {
+        m_content = ConfigUtils.normalizeString(content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_content);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof Filter) {
+            final Filter that = (Filter)obj;
+            return Objects.equals(this.m_content, that.m_content);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperator.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperator.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+@XmlJavaTypeAdapter(FilterOperatorAdapter.class)
+@XmlRootElement(name="filterOperator")
+@XmlEnum
+public enum FilterOperator {
+    @XmlEnumValue("and")
+    AND,
+    @XmlEnumValue("or")
+    OR;
+
+    public String getEnumName() {
+        return this.toString().toLowerCase();
+    }
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperatorAdapter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperatorAdapter.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * @since 1.0.0
+ */
+public class FilterOperatorAdapter extends XmlAdapter<String, FilterOperator> {
+
+    @Override
+    public FilterOperator unmarshal(final String v) {
+        if (v == null) return null;
+        return FilterOperator.valueOf(v.toUpperCase());
+    }
+
+    @Override
+    public String marshal(final FilterOperator v) {
+        return v.toString();
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Group.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Group.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Grouping of related threshold definitions
+ */
+@XmlRootElement(name = "group")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Group implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Group name
+     */
+    @XmlAttribute(name = "name", required = true)
+    private String m_name;
+
+    /**
+     * Full path to the RRD repository where the data is stored
+     *
+     */
+    @XmlAttribute(name = "rrdRepository", required = true)
+    private String m_rrdRepository;
+
+    /**
+     * Threshold definition
+     */
+    @XmlElement(name = "threshold")
+    private List<Threshold> m_thresholds = new ArrayList<>();
+
+    /**
+     * Expression definition
+     */
+    @XmlElement(name = "expression")
+    private List<Expression> m_expressions = new ArrayList<>();
+
+    public Group() { }
+
+    public String getName() {
+        return m_name;
+    }
+
+    public void setName(final String name) {
+        m_name = ConfigUtils.assertNotEmpty(name, "name");
+    }
+
+    public String getRrdRepository() {
+        return m_rrdRepository;
+    }
+
+    public void setRrdRepository(final String rrdRepository) {
+        m_rrdRepository = ConfigUtils.assertNotEmpty(rrdRepository, "rrdRepository");
+    }
+
+    public List<Threshold> getThresholds() {
+        return m_thresholds;
+    }
+
+    public void setThresholds(final List<Threshold> thresholds) {
+        if (thresholds == m_thresholds) return;
+        m_thresholds.clear();
+        if (thresholds != null) m_thresholds.addAll(thresholds);
+    }
+
+    public void addThreshold(final Threshold threshold) {
+        m_thresholds.add(threshold);
+    }
+
+    public boolean removeThreshold(final Threshold threshold) {
+        return m_thresholds.remove(threshold);
+    }
+
+    public List<Expression> getExpressions() {
+        return m_expressions;
+    }
+
+    public void setExpressions(final List<Expression> expressions) {
+        if (expressions == m_expressions) return;
+        m_expressions.clear();
+        if (expressions != null) m_expressions.addAll(expressions);
+    }
+
+    public void addExpression(final Expression expression) {
+        m_expressions.add(expression);
+    }
+
+    public boolean removeExpression(final Expression expression) {
+        return m_expressions.remove(expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_name,
+                m_rrdRepository,
+                m_thresholds,
+                m_expressions);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof Group) {
+            final Group that = (Group)obj;
+            return Objects.equals(this.m_name, that.m_name)
+                    && Objects.equals(this.m_rrdRepository, that.m_rrdRepository)
+                    && Objects.equals(this.m_thresholds, that.m_thresholds)
+                    && Objects.equals(this.m_expressions, that.m_expressions);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/IncludeRange.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/IncludeRange.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Range of adresses to be included in this
+ *  package
+ */
+@XmlRootElement(name = "include-range")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class IncludeRange implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Starting address of the range
+     */
+    @XmlAttribute(name = "begin", required = true)
+    private String m_begin;
+
+    /**
+     * Ending address of the range
+     */
+    @XmlAttribute(name = "end", required = true)
+    private String m_end;
+
+    public IncludeRange() {
+    }
+
+    public String getBegin() {
+        return m_begin;
+    }
+
+    public void setBegin(final String begin) {
+        m_begin = ConfigUtils.assertNotEmpty(begin, "begin");
+    }
+
+    public String getEnd() {
+        return m_end;
+    }
+
+    public void setEnd(final String end) {
+        m_end = ConfigUtils.assertNotEmpty(end, "end");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_begin, m_end);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof IncludeRange) {
+            final IncludeRange that = (IncludeRange)obj;
+            return Objects.equals(this.m_begin, that.m_begin)
+                    && Objects.equals(this.m_end, that.m_end);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Package.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Package.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Package encapsulating addresses eligible for
+ *  thresholding.
+ */
+@XmlRootElement(name = "package")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Package implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Name or identifier for this package
+     */
+    @XmlAttribute(name = "name", required = true)
+    private String m_name;
+
+    /**
+     * A rule which addresses belonging to this package
+     *  must pass. This package is applied only to addresses that pass
+     *  this filter
+     */
+    @XmlElement(name = "filter", required = true)
+    private Filter m_filter;
+
+    /**
+     * Adresses in this package
+     */
+    @XmlElement(name = "specific")
+    private List<String> m_specifics = new ArrayList<>();
+
+    /**
+     * Range of addresses in this package
+     */
+    @XmlElement(name = "include-range")
+    private List<IncludeRange> m_includeRanges = new ArrayList<>();
+
+    /**
+     * Range of addresses to be excluded from this
+     *  package
+     */
+    @XmlElement(name = "exclude-range")
+    private List<ExcludeRange> m_excludeRanges = new ArrayList<>();
+
+    /**
+     * A file URL holding specific addresses to be polled.
+     *  Each line in the URL file can be one of:
+     *  <IP><space>#<comments>, or <IP>, or
+     *  #<comments>. Lines starting with a '#' are ignored and so
+     *  are characters after a '<space>#' in a line.
+     */
+    @XmlElement(name = "include-url")
+    private List<String> m_includeUrls = new ArrayList<>();
+
+    /**
+     * Services for which thresholding is to occur in this package
+     */
+    @XmlElement(name = "service")
+    private List<Service> m_services = new ArrayList<>();
+
+    /**
+     * Scheduled outages. Thresholding is not performed
+     *  during scheduled outages.
+     */
+    @XmlElement(name = "outage-calendar")
+    private List<String> m_outageCalendars = new ArrayList<>();
+
+    public Package() { }
+
+    public String getName() {
+        return m_name;
+    }
+
+    public void setName(final String name) {
+        m_name = ConfigUtils.assertNotEmpty(name, "name");
+    }
+
+    public Filter getFilter() {
+        return m_filter;
+    }
+
+    public void setFilter(final Filter filter) {
+        m_filter = ConfigUtils.assertNotNull(filter, "filter");
+    }
+
+    public List<String> getSpecifics() {
+        return m_specifics;
+    }
+
+    public void setSpecifics(final List<String> specifics) {
+        if (specifics == m_specifics) return;
+        m_specifics.clear();
+        if (specifics != null) m_specifics.addAll(specifics);
+    }
+
+    public void addSpecific(final String specific) {
+        m_specifics.add(specific);
+    }
+
+    public boolean removeSpecific(final String specific) {
+        return m_specifics.remove(specific);
+    }
+
+    public List<IncludeRange> getIncludeRanges() {
+        return m_includeRanges;
+    }
+
+    public void setIncludeRanges(final List<IncludeRange> includeRanges) {
+        if (includeRanges == m_includeRanges) return;
+        m_includeRanges.clear();
+        if (includeRanges != null) m_includeRanges.addAll(includeRanges);
+    }
+
+    public void addIncludeRange(final IncludeRange includeRange) {
+        m_includeRanges.add(includeRange);
+    }
+
+    public boolean removeIncludeRange(final IncludeRange includeRange) {
+        return m_includeRanges.remove(includeRange);
+    }
+
+    public List<ExcludeRange> getExcludeRanges() {
+        return m_excludeRanges;
+    }
+
+    public void setExcludeRanges(final List<ExcludeRange> excludeRanges) {
+        if (excludeRanges == m_excludeRanges) return;
+        m_excludeRanges.clear();
+        if (excludeRanges != null) m_excludeRanges.addAll(excludeRanges);
+    }
+
+    public void addExcludeRange(final ExcludeRange excludeRange) {
+        m_excludeRanges.add(excludeRange);
+    }
+
+    public boolean removeExcludeRange(final ExcludeRange excludeRange) {
+        return m_excludeRanges.remove(excludeRange);
+    }
+
+    public List<String> getIncludeUrls() {
+        return m_includeUrls;
+    }
+
+    public void setIncludeUrls(final List<String> includeUrls) {
+        if (includeUrls == m_includeUrls) return;
+        m_includeUrls.clear();
+        if (includeUrls != null) m_includeUrls.addAll(includeUrls);
+    }
+
+    public void addIncludeUrl(final String includeUrl) {
+        m_includeUrls.add(includeUrl);
+    }
+
+    public boolean removeIncludeUrl(final String includeUrl) {
+        return m_includeUrls.remove(includeUrl);
+    }
+
+    public List<Service> getServices() {
+        return m_services;
+    }
+
+    public void setServices(final List<Service> services) {
+        if (services == m_services) return;
+        m_services.clear();
+        if (services != null) m_services.addAll(services);
+    }
+
+    public void addService(final Service service) {
+        m_services.add(service);
+    }
+
+    public boolean removeService(final Service service) {
+        return m_services.remove(service);
+    }
+
+    public List<String> getOutageCalendars() {
+        return m_outageCalendars;
+    }
+
+    public void setOutageCalendars(final List<String> outageCalendars) {
+        if (outageCalendars == m_outageCalendars) return;
+        m_outageCalendars.clear();
+        if (outageCalendars != null) m_outageCalendars.addAll(outageCalendars);
+    }
+
+    public void addOutageCalendar(final String outageCalendar) {
+        m_outageCalendars.add(outageCalendar);
+    }
+
+    public boolean removeOutageCalendar(final String outageCalendar) {
+        return m_outageCalendars.remove(outageCalendar);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_name,
+                m_filter,
+                m_specifics,
+                m_includeRanges,
+                m_excludeRanges,
+                m_includeUrls,
+                m_services,
+                m_outageCalendars);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof Package) {
+            final Package that = (Package)obj;
+            return Objects.equals(this.m_name, that.m_name)
+                    && Objects.equals(this.m_filter, that.m_filter)
+                    && Objects.equals(this.m_specifics, that.m_specifics)
+                    && Objects.equals(this.m_includeRanges, that.m_includeRanges)
+                    && Objects.equals(this.m_excludeRanges, that.m_excludeRanges)
+                    && Objects.equals(this.m_includeUrls, that.m_includeUrls)
+                    && Objects.equals(this.m_services, that.m_services)
+                    && Objects.equals(this.m_outageCalendars, that.m_outageCalendars);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Parameter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Parameter.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Parameters to be used for threshold checking this
+ *  service. Parameters are specfic to the service
+ *  thresholder.
+ */
+@XmlRootElement(name = "parameter")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Parameter implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    @XmlAttribute(name = "key", required = true)
+    private String m_key;
+
+    @XmlAttribute(name = "value", required = true)
+    private String m_value;
+
+    public Parameter() {
+    }
+
+    public String getKey() {
+        return m_key;
+    }
+
+    public void setKey(final String key) {
+        m_key = ConfigUtils.assertNotEmpty(key, "key");
+    }
+
+    public String getValue() {
+        return m_value;
+    }
+
+    public void setValue(final String value) {
+        m_value = ConfigUtils.assertNotEmpty(value, "value");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_key, m_value);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof Parameter) {
+            final Parameter that = (Parameter)obj;
+            return Objects.equals(this.m_key, that.m_key)
+                    && Objects.equals(this.m_value, that.m_value);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ResourceFilter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ResourceFilter.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+@XmlRootElement(name = "resource-filter")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ResourceFilter implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * internal content storage
+     */
+    @XmlValue
+    private String m_content;
+
+    @XmlAttribute(name = "field", required = true)
+    private String m_field;
+
+    public ResourceFilter() { }
+
+    public Optional<String> getContent() {
+        return Optional.ofNullable(m_content);
+    }
+
+    public void setContent(final String content) {
+        m_content = ConfigUtils.normalizeString(content);
+    }
+
+    public String getField() {
+        return m_field;
+    }
+
+    public void setField(final String field) {
+        m_field = ConfigUtils.assertNotEmpty(field, "field");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_content, m_field);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof ResourceFilter) {
+            final ResourceFilter that = (ResourceFilter)obj;
+            return Objects.equals(this.m_content, that.m_content)
+                    && Objects.equals(this.m_field, that.m_field);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Service.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Service.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Service for which thresholding is to be performed for
+ *  addresses in this package
+ */
+@XmlRootElement(name = "service")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Service implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Service name
+     */
+    @XmlAttribute(name = "name", required = true)
+    private String m_name;
+
+    /**
+     * Interval at which the service is to be threshold
+     *  checked
+     */
+    @XmlAttribute(name = "interval", required = true)
+    private Long m_interval;
+
+    /**
+     * Specifies if this is a user-defined service. Used
+     *  specifically for UI purposes.
+     */
+    @XmlAttribute(name = "user-defined")
+    private Boolean m_userDefined;
+
+    /**
+     * Thresholding status for this service. Service is
+     *  checked against thresholds only if set to 'on'.
+     */
+    @XmlAttribute(name = "status")
+    private ServiceStatus m_status;
+
+    /**
+     * Parameters to be used for threshold checking this
+     *  service. Parameters are specfic to the service
+     *  thresholder.
+     */
+    @XmlElement(name = "parameter")
+    private List<Parameter> m_parameters = new ArrayList<>();
+
+    public Service() {
+    }
+
+    public String getName() {
+        return m_name;
+    }
+
+    public void setName(final String name) {
+        m_name = ConfigUtils.assertNotEmpty(name, "name");
+    }
+
+    public Long getInterval() {
+        return m_interval;
+    }
+
+    public void setInterval(final Long interval) {
+        m_interval = ConfigUtils.assertNotNull(interval, "interval");
+    }
+
+    public Boolean getUserDefined() {
+        return m_userDefined;
+    }
+
+    public void setUserDefined(final Boolean userDefined) {
+        m_userDefined = userDefined;
+    }
+
+    public Optional<ServiceStatus> getStatus() {
+        return Optional.ofNullable(m_status);
+    }
+
+    public void setStatus(final ServiceStatus status) {
+        m_status = status;
+    }
+
+    public List<Parameter> getParameters() {
+        return m_parameters;
+    }
+
+    public void setParameters(final List<Parameter> parameters) {
+        if (parameters == m_parameters) return;
+        m_parameters.clear();
+        if (parameters != null) m_parameters.addAll(parameters);
+    }
+
+    public void addParameter(final Parameter parameter) {
+        m_parameters.add(parameter);
+    }
+
+    public boolean removeParameter(final Parameter parameter) {
+        return m_parameters.remove(parameter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_name,
+                m_interval,
+                m_userDefined,
+                m_status,
+                m_parameters);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof Service) {
+            final Service that = (Service)obj;
+            return Objects.equals(this.m_name, that.m_name)
+                    && Objects.equals(that.m_interval, that.m_interval)
+                    && Objects.equals(that.m_userDefined, that.m_userDefined)
+                    && Objects.equals(that.m_status, that.m_status)
+                    && Objects.equals(that.m_parameters, that.m_parameters);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ServiceStatus.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ServiceStatus.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name="status")
+@XmlEnum
+public enum ServiceStatus {
+    @XmlEnumValue("on")
+    ON,
+    @XmlEnumValue("off")
+    OFF
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThreshdConfiguration.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThreshdConfiguration.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Top-level element for the threshd-configuration.xml
+ *  configuration file.
+ */
+@XmlRootElement(name = "threshd-configuration")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ThreshdConfiguration implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Maximum number of threads used for
+     *  thresholding.
+     */
+    @XmlAttribute(name = "threads", required = true)
+    private Integer m_threads;
+
+    /**
+     * Package encapsulating addresses eligible for
+     *  thresholding.
+     */
+    @XmlElement(name = "package", required = true)
+    private List<Package> m_packages = new ArrayList<>();
+
+    /**
+     * Service thresholders
+     */
+    @XmlElement(name = "thresholder")
+    private List<Thresholder> m_thresholders = new ArrayList<>();
+
+    public ThreshdConfiguration() { }
+
+    public Integer getThreads() {
+        return m_threads;
+    }
+
+    public void setThreads(final Integer threads) {
+        m_threads = ConfigUtils.assertNotNull(threads, "threads");
+    }
+
+    public List<Package> getPackages() {
+        return m_packages;
+    }
+
+    public void setPackages(final List<Package> packages) {
+        if (packages == m_packages) return;
+        m_packages.clear();
+        if (packages != null) m_packages.addAll(packages);
+    }
+
+    public Optional<Package> getPackage(String packageName) {
+        return getPackages().stream()
+                .filter(p -> Objects.equals(packageName, p.getName()))
+                .findFirst();
+    }
+
+    public void addPackage(final Package p) {
+        m_packages.add(p);
+    }
+
+    public boolean removePackage(final Package p) {
+        return m_packages.remove(p);
+    }
+
+    public List<Thresholder> getThresholders() {
+        return m_thresholders;
+    }
+
+    public void setThresholders(final List<Thresholder> thresholders) {
+        if (thresholders == m_thresholders) return;
+        m_thresholders.clear();
+        if (thresholders != null) m_thresholders.addAll(thresholders);
+    }
+
+    public void addThresholder(final Thresholder thresholder) {
+        m_thresholders.add(thresholder);
+    }
+
+    public boolean removeThresholder(final Thresholder thresholder) {
+        return m_thresholders.remove(thresholder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_threads,
+                m_packages,
+                m_thresholders);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof ThreshdConfiguration) {
+            final ThreshdConfiguration that = (ThreshdConfiguration)obj;
+            return Objects.equals(this.m_threads, that.m_threads)
+                    && Objects.equals(this.m_packages, that.m_packages)
+                    && Objects.equals(this.m_thresholders, that.m_thresholders);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Threshold.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Threshold.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Threshold definition
+ */
+@XmlRootElement(name = "threshold")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Threshold extends Basethresholddef implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * RRD datasource name. Mutually exclusive with expression,
+     *  but one of them must be specified
+     */
+    @XmlAttribute(name = "ds-name", required = true)
+    private String m_dsName;
+
+    public Threshold() { }
+
+    public String getDsName() {
+        return m_dsName;
+    }
+
+    public void setDsName(final String dsName) {
+        m_dsName = ConfigUtils.assertNotEmpty(dsName, "ds-name");
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + Objects.hash(m_dsName);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (super.equals(obj)==false) {
+            return false;
+        }
+
+        if (obj instanceof Threshold) {
+            final Threshold that = (Threshold)obj;
+            return Objects.equals(this.m_dsName, that.m_dsName);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdType.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdType.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name="type")
+@XmlEnum
+public enum ThresholdType {
+    @XmlEnumValue("high")
+    HIGH("high"),
+    @XmlEnumValue("low")
+    LOW("low"),
+    @XmlEnumValue("relativeChange")
+    RELATIVE_CHANGE("relativeChange"),
+    @XmlEnumValue("absoluteChange")
+    ABSOLUTE_CHANGE("absoluteChange"),
+    @XmlEnumValue("rearmingAbsoluteChange")
+    REARMING_ABSOLUTE_CHANGE("rearmingAbsoluteChange");
+
+    private String m_enumName;
+
+    ThresholdType(final String enumName) {
+        m_enumName = enumName;
+    }
+
+    public String getEnumName() {
+        return m_enumName;
+    }
+
+    public static ThresholdType forName(final String name) {
+        for (final ThresholdType type : ThresholdType.values()) {
+            if (name.equalsIgnoreCase(type.getEnumName())) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Thresholder.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Thresholder.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.opennms.integration.api.xml.ConfigUtils;
+
+/**
+ * Thresholder for a service
+ */
+@XmlRootElement(name = "thresholder")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Thresholder implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Service name
+     */
+    @XmlAttribute(name = "service", required = true)
+    private String m_service;
+
+    /**
+     * Java class name used to perform thresholding via the
+     *  service
+     */
+    @XmlAttribute(name = "class-name", required = true)
+    private String m_className;
+
+    /**
+     * Parameters to be used for threshold checking this
+     *  service. Parameters are specfic to the service
+     *  thresholder.
+     */
+    @XmlElement(name = "parameter")
+    private List<Parameter> m_parameters = new ArrayList<>();
+
+    public Thresholder() { }
+
+    public String getService() {
+        return m_service;
+    }
+
+    public void setService(final String service) {
+        m_service = ConfigUtils.assertNotEmpty(service, "service");
+    }
+
+    public String getClassName() {
+        return m_className;
+    }
+
+    public void setClassName(final String className) {
+        m_className = ConfigUtils.assertNotEmpty(className, "class-name");
+    }
+
+    public List<Parameter> getParameters() {
+        return m_parameters;
+    }
+
+    public void setParameters(final List<Parameter> parameters) {
+        if (parameters == m_parameters) return;
+        m_parameters.clear();
+        if (parameters != null) m_parameters.addAll(parameters);
+    }
+
+    public void addParameter(final Parameter parameter) {
+        m_parameters.add(parameter);
+    }
+
+    public boolean removeParameter(final Parameter parameter) {
+        return m_parameters.remove(parameter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_service,
+                m_className,
+                m_parameters);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof Thresholder) {
+            final Thresholder that = (Thresholder)obj;
+            return Objects.equals(this.m_service, that.m_service)
+                    && Objects.equals(this.m_className, that.m_className)
+                    && Objects.equals(this.m_parameters, that.m_parameters);
+        }
+        return false;
+    }
+
+}

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdingConfig.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdingConfig.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.xml.schema.thresholding;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Top-level element for the thresholds.xml configuration file.
+ */
+@XmlRootElement(name = "thresholding-config")
+@XmlAccessorType(XmlAccessType.NONE)
+public class ThresholdingConfig implements Serializable {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Thresholding group element
+     */
+    private List<Group> m_groups = new ArrayList<>();
+
+    private final Map<String, Group> m_groupMap = new ConcurrentHashMap<>();
+
+    public ThresholdingConfig() {
+    }
+
+    @XmlElement(name = "group")
+    public List<Group> getGroups() {
+        return m_groups;
+    }
+
+    public void setGroups(final List<Group> groups) {
+        if (groups == m_groups) {
+            // Cover the case where jax-b already set the field reflectively and is now calling our setter in which case
+            // we just need to make sure the group map is populated
+            if (m_groupMap.isEmpty()) {
+                groups.forEach(g -> m_groupMap.put(g.getName(), g));
+            }
+        } else {
+            m_groups.clear();
+            m_groupMap.clear();
+            if (groups != null) {
+                m_groups.addAll(groups);
+                groups.forEach(g -> m_groupMap.put(g.getName(), g));
+            }
+        }
+    }
+
+    public Group getGroup(String groupName) {
+        Objects.requireNonNull(groupName);
+        Group group = m_groupMap.get(groupName);
+        if (group == null) {
+            throw new IllegalArgumentException("Thresholding group " + groupName + " does not exist.");
+        }
+        return group;
+    }
+
+    public void addGroup(final Group group) {
+        m_groups.add(group);
+        m_groupMap.put(group.getName(), group);
+    }
+
+    public boolean removeGroup(final Group group) {
+        m_groupMap.remove(group.getName());
+        return m_groups.remove(group);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(m_groups);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+
+        if (obj instanceof ThresholdingConfig) {
+            final ThresholdingConfig that = (ThresholdingConfig)obj;
+            return Objects.equals(this.m_groups, that.m_groups);
+        }
+        return false;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,8 @@
                         </goals>
                         <configuration>
                             <additionalparam>${javadoc.opts}</additionalparam>
+                            <!-- Some of the JAX-B objects have javadoc that can't be parsed so we exclude them here -->
+                            <excludePackageNames>org.opennms.integration.api.xml.schema.*</excludePackageNames>
                         </configuration>
                     </execution>
                 </executions>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtension.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.sample;
+
+import java.util.List;
+
+import org.opennms.integration.api.v1.config.thresholding.PackageDefinition;
+import org.opennms.integration.api.v1.config.thresholding.ThreshdConfigurationExtension;
+import org.opennms.integration.api.v1.config.thresholding.ThresholderDefinition;
+import org.opennms.integration.api.xml.ClasspathThreshdConfigurationLoader;
+
+public class MyThreshdConfigurationExtension implements ThreshdConfigurationExtension {
+    private final ClasspathThreshdConfigurationLoader classpathThreshdConfigurationLoader =
+            new ClasspathThreshdConfigurationLoader(MyThresholdingConfigExtension.class, "threshd-configuration.1" +
+                    ".xml", "threshd-configuration.2.xml");
+
+
+    @Override
+    public Integer getThreads() {
+        return classpathThreshdConfigurationLoader.getThreads();
+    }
+
+    @Override
+    public List<PackageDefinition> getPackages() {
+        return classpathThreshdConfigurationLoader.getPackages();
+    }
+
+    @Override
+    public List<ThresholderDefinition> getThresholders() {
+        return classpathThreshdConfigurationLoader.getThresholders();
+    }
+}

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyThresholdingConfigExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyThresholdingConfigExtension.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.sample;
+
+import java.util.List;
+
+import org.opennms.integration.api.v1.config.thresholding.GroupDefinition;
+import org.opennms.integration.api.v1.config.thresholding.ThresholdingConfigExtension;
+import org.opennms.integration.api.xml.ClasspathThresholdingConfigLoader;
+
+public class MyThresholdingConfigExtension implements ThresholdingConfigExtension {
+    private final ClasspathThresholdingConfigLoader classpathThresholdingConfigLoader =
+            new ClasspathThresholdingConfigLoader(MyThresholdingConfigExtension.class, "thresholds.1.xml",
+                    "thresholds.2.xml");
+
+    @Override
+    public List<GroupDefinition> getGroupDefinitions() {
+        return classpathThresholdingConfigLoader.getGroupDefinitions();
+    }
+}

--- a/sample/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/sample/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -92,6 +92,14 @@
         <bean class="org.opennms.integration.api.sample.MyGraphPropertiesExtension"/>
     </service>
 
+    <service interface="org.opennms.integration.api.v1.config.thresholding.ThresholdingConfigExtension">
+        <bean class="org.opennms.integration.api.sample.MyThresholdingConfigExtension"/>
+    </service>
+
+    <service interface="org.opennms.integration.api.v1.config.thresholding.ThreshdConfigurationExtension">
+        <bean class="org.opennms.integration.api.sample.MyThreshdConfigurationExtension"/>
+    </service>
+
     <service interface="org.opennms.integration.api.v1.detectors.ServiceDetectorFactory">
         <bean class="org.opennms.integration.api.sample.SampleDetectorFactory"/>
     </service>

--- a/sample/src/main/resources/thresholding/threshd-configuration.1.xml
+++ b/sample/src/main/resources/thresholding/threshd-configuration.1.xml
@@ -1,0 +1,10 @@
+<threshd-configuration threads="5">
+    <package name="MyTestPackage1">
+        <filter>IPADDR != '0.0.0.0'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="MyTestService1" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="MyTestGroup1"/>
+        </service>
+    </package>
+</threshd-configuration>

--- a/sample/src/main/resources/thresholding/threshd-configuration.2.xml
+++ b/sample/src/main/resources/thresholding/threshd-configuration.2.xml
@@ -1,0 +1,10 @@
+<threshd-configuration threads="10">
+    <package name="MyTestPackage2">
+        <filter>IPADDR != '0.0.0.0'</filter>
+        <include-range begin="1.1.1.1" end="254.254.254.254"/>
+        <include-range begin="::1" end="ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"/>
+        <service name="MyTestService2" interval="300000" user-defined="false" status="on">
+            <parameter key="thresholding-group" value="MyTestGroup2"/>
+        </service>
+    </package>
+</threshd-configuration>

--- a/sample/src/main/resources/thresholding/thresholds.1.xml
+++ b/sample/src/main/resources/thresholding/thresholds.1.xml
@@ -1,0 +1,5 @@
+<thresholding-config>
+    <group name="MyTestGroup1" rrdRepository="/opt/opennms/share/rrd/snmp/">
+        <expression description="Test1" type="high" ds-type="if" value="100000" rearm="75000" trigger="1" ds-label="ifName" filterOperator="OR" expression="ifInOctets + ifOutOctets"/>
+    </group>
+</thresholding-config>

--- a/sample/src/main/resources/thresholding/thresholds.2.xml
+++ b/sample/src/main/resources/thresholding/thresholds.2.xml
@@ -1,0 +1,5 @@
+<thresholding-config>
+    <group name="MyTestGroup2" rrdRepository="/opt/opennms/share/rrd/snmp/">
+        <expression description="Test2" type="high" ds-type="if" value="100000" rearm="75000" trigger="1" ds-label="ifName" filterOperator="OR" expression="ifInOctets + ifOutOctets"/>
+    </group>
+</thresholding-config>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtensionTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.sample;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.config.thresholding.PackageDefinition;
+import org.opennms.integration.api.v1.config.thresholding.Parameter;
+import org.opennms.integration.api.v1.config.thresholding.Service;
+import org.opennms.integration.api.v1.config.thresholding.ServiceStatus;
+
+public class MyThreshdConfigurationExtensionTest {
+    @Test
+    public void canReadPackageDefinitionsFromExtension() {
+        MyThreshdConfigurationExtension myThreshdConfigurationExtension = new MyThreshdConfigurationExtension();
+        assertThat(myThreshdConfigurationExtension.getThreads(), equalTo(10));
+        assertThat(myThreshdConfigurationExtension.getThresholders(), hasSize(0));
+        List<PackageDefinition> packages = myThreshdConfigurationExtension.getPackages();
+        assertThat(packages, hasSize(2));
+
+        PackageDefinition myTestPackage1 = packages.stream()
+                .filter(pd -> pd.getName().equals("MyTestPackage1"))
+                .findAny()
+                .get();
+
+        assertThat(myTestPackage1.getFilter().getContent().get(), equalTo("IPADDR != '0.0.0.0'"));
+
+        Service myTestService1 = myTestPackage1.getServices().get(0);
+        assertThat(myTestService1.getName(), equalTo("MyTestService1"));
+        assertThat(myTestService1.getInterval(), equalTo(300000L));
+        assertThat(myTestService1.getUserDefined(), equalTo(false));
+        assertThat(myTestService1.getStatus().get(), equalTo(ServiceStatus.ON));
+
+        Parameter p1 = myTestService1.getParameters().get(0);
+        assertThat(p1.getKey(), equalTo("thresholding-group"));
+        assertThat(p1.getValue(), equalTo("MyTestGroup1"));
+    }
+}

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyThresholdingConfigExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyThresholdingConfigExtensionTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.sample;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.config.thresholding.Expression;
+import org.opennms.integration.api.v1.config.thresholding.GroupDefinition;
+import org.opennms.integration.api.v1.config.thresholding.ThresholdType;
+
+public class MyThresholdingConfigExtensionTest {
+    @Test
+    public void canReadPackageDefinitionsFromExtension() {
+        MyThresholdingConfigExtension myThresholdingConfigExtension = new MyThresholdingConfigExtension();
+        List<GroupDefinition> groupDefinitions = myThresholdingConfigExtension.getGroupDefinitions();
+        assertThat(groupDefinitions, hasSize(2));
+
+        GroupDefinition myTestGroup1 = groupDefinitions.stream()
+                .filter(gd -> gd.getName().equals("MyTestGroup1"))
+                .findAny()
+                .get();
+        assertThat(myTestGroup1.getRrdRepository(), equalTo("/opt/opennms/share/rrd/snmp/"));
+
+        Expression test1 = myTestGroup1.getExpressions().get(0);
+        assertThat(test1.getDescription().get(), equalTo("Test1"));
+        assertThat(test1.getType(), equalTo(ThresholdType.HIGH));
+        assertThat(test1.getDsType(), equalTo("if"));
+        assertThat(test1.getValue(), equalTo(100000.0));
+        assertThat(test1.getRearm(), equalTo(75000.0));
+        assertThat(test1.getTrigger(), equalTo(1));
+        assertThat(test1.getDsLabel().get(), equalTo("ifName"));
+        assertThat(test1.getFilterOperator().getEnumName(), equalTo("or"));
+        assertThat(test1.getExpression(), equalTo("ifInOctets + ifOutOctets"));
+    }
+}


### PR DESCRIPTION
This PR updates the integration API to allow extension of OpenNMS thresholding configuration (thresholds.xml and threshd-configuration.xml).

The JAX-B annotated classes are copies from OpenNMS.

A sample configuration extension has been provided that extends the configuration via XML files bundled in the classpath.