### PR TITLE
NNMS-12383 Timeseries Integration Layer

### DIFF
--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
@@ -94,9 +94,9 @@ public class ImmutableMetric implements Metric {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ImmutableMetric metric = (ImmutableMetric) o;
-        return Objects.equals(tags, metric.tags);
+        if (!(o instanceof Metric)) return false;
+        Metric metric = (Metric) o;
+        return Objects.equals(tags, metric.getTags());
     }
 
     // the metric (timeseries) identity is directly tied to the metric key (if any) and tags values (but not their order).

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
@@ -136,7 +136,7 @@ public class ImmutableMetric implements Metric {
         }
 
         public MetricBuilder tag(String value) {
-            return this.metaTag(new ImmutableTag(value));
+            return this.tag(new ImmutableTag(value));
         }
 
         public MetricBuilder metaTag(Tag tag) {

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableSample.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableSample.java
@@ -65,11 +65,11 @@ public class ImmutableSample implements Sample {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ImmutableSample that = (ImmutableSample) o;
-        return Objects.equals(metric, that.metric) &&
-                Objects.equals(time, that.time) &&
-                Objects.equals(value, that.value);
+        if (!(o instanceof Sample)) return false;
+        Sample that = (Sample) o;
+        return Objects.equals(metric, that.getMetric()) &&
+                Objects.equals(time, that.getTime()) &&
+                Objects.equals(value, that.getValue());
     }
 
     @Override

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
@@ -68,10 +68,10 @@ public class ImmutableTag implements Tag {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ImmutableTag tag = (ImmutableTag) o;
-        return Objects.equals(key, tag.key) &&
-                Objects.equals(value, tag.value);
+        if (!(o instanceof Tag)) return false;
+        Tag tag = (Tag) o;
+        return Objects.equals(key, tag.getKey()) &&
+                Objects.equals(value, tag.getValue());
     }
 
     @Override

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
@@ -30,7 +30,6 @@ package org.opennms.integration.api.v1.timeseries.immutables;
 
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.StringJoiner;
 
 import org.opennms.integration.api.v1.timeseries.Tag;
 
@@ -53,10 +52,7 @@ public class ImmutableTag implements Tag {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", ImmutableTag.class.getSimpleName() + "[", "]")
-                .add("key='" + key + "'")
-                .add("value='" + value + "'")
-                .toString();
+        return key + "=" + value;
     }
 
     @Override
@@ -89,8 +85,8 @@ public class ImmutableTag implements Tag {
             return 1;
         }
         return Comparator
-                .comparing(Tag::getKey)
-                .thenComparing(Tag::getValue)
+                .comparing(Tag::getKey, Comparator.nullsFirst(Comparator.naturalOrder()))
+                .thenComparing(Tag::getValue) // cannot be null
                 .compare(this, other);
     }
 }

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTimeSeriesFetchRequest.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTimeSeriesFetchRequest.java
@@ -94,13 +94,13 @@ public class ImmutableTimeSeriesFetchRequest implements TimeSeriesFetchRequest {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ImmutableTimeSeriesFetchRequest that = (ImmutableTimeSeriesFetchRequest) o;
-        return Objects.equals(metric, that.metric) &&
-                Objects.equals(start, that.start) &&
-                Objects.equals(end, that.end) &&
-                Objects.equals(step, that.step) &&
-                aggregation == that.aggregation;
+        if (!(o instanceof TimeSeriesFetchRequest)) return false;
+        TimeSeriesFetchRequest that = (TimeSeriesFetchRequest) o;
+        return Objects.equals(metric, that.getMetric()) &&
+                Objects.equals(start, that.getStart()) &&
+                Objects.equals(end, that.getEnd()) &&
+                Objects.equals(step, that.getStep()) &&
+                aggregation == that.getAggregation();
     }
 
     @Override

--- a/common/src/test/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetricTest.java
+++ b/common/src/test/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetricTest.java
@@ -28,6 +28,7 @@
 
 package org.opennms.integration.api.v1.timeseries.immutables;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -56,5 +57,18 @@ public class ImmutableMetricTest {
             fail("Expected Exception " + expectedType.getName() + " but caught " + t.getClass());
         }
         fail("Expected Exception " + expectedType.getName() + " was not thrown");
+    }
+
+    @Test
+    public void shouldGenerateKey() {
+        // we want to keep this format since the implementations will rely on it.
+        assertEquals("null=a_mtype=counter_tag2=b_tag3=c_unit=ms", ImmutableMetric.builder()
+                .tag( "a")
+                .tag("tag3", "c")
+                .tag("tag2", "b")
+                .tag(ImmutableMetric.MandatoryTag.unit.name(), "ms")
+                .tag(ImmutableMetric.MandatoryTag.mtype.name(), ImmutableMetric.Mtype.counter.name())
+                .metaTag("shouldn't be included", "-")
+                .build().getKey());
     }
 }


### PR DESCRIPTION
This PR fixes equals in the Immutable timeseries classes: The former implementation didn't work with multiple class loaders (as used in osgi)