### PR TITLE
NMS-12633 add more StorageException constructors

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/StorageException.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/StorageException.java
@@ -29,7 +29,16 @@
 package org.opennms.integration.api.v1.timeseries;
 
 public class StorageException extends Exception {
-    public StorageException (Exception e) {
+
+    public StorageException(final String message) {
+        super(message);
+    }
+
+    public StorageException (final Throwable e) {
+        super(e);
+    }
+
+    public StorageException (final String message, Throwable e) {
         super(e);
     }
 }


### PR DESCRIPTION
This PR add more constructors for to the StorageException. Needed by InfluxDb Plugin:
https://issues.opennms.org/browse/NMS-12633