### PR TITLE
OIA-20: Update CircleCI environment to use Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,14 @@
-version: 2
+---
+version: 2.1
 
+executors:
+  build-executor:
+    docker:
+      - image: circleci/openjdk:11.0.7-jdk-buster
 
 jobs:
   build:
-    docker:
-      - image: circleci/openjdk:11.0.7-jdk-buster
-    working_directory: /home/circleci/api
-
+    executor: build-executor
     environment:
       MAVEN_OPTS: -Xmx1024m
 
@@ -59,18 +61,15 @@ jobs:
           path: ~/junit
 
       - persist_to_workspace:
-          root: /home/circleci
+          root: ~/
           paths:
-            - api
+            - project
 
   deploy:
-    machine: true
-
-    working_directory: /home/circleci/api
-
+    executor: build-executor
     steps:
       - attach_workspace:
-          at: /home/circleci
+          at: ~/
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
Use 2.1 CircleCI configurations and a Docker build executor maintained by CircleCI with OpenJDK 11.0.7-jdk. Use the default CircleCI project work directory.
 