### PR TITLE
OIA-26: Expose intrinsic tag names as constants for TSS API

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/IntrinsicTagNames.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/IntrinsicTagNames.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2010-2019 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.timeseries;
+
+/** common tag names used to define the intrinsic tags of a metric. */
+public interface IntrinsicTagNames {
+    String name = "name";
+    String resourceId = "resourceId";
+    String mtype = "mtype";
+}


### PR DESCRIPTION
Moves the intrinsic tag names from opennms to integration api

Jira: https://issues.opennms.org/browse/OIA-26