### PR TITLE
Remove dependency on guava from the config module.

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -15,10 +15,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opennms.integration.api</groupId>
             <artifactId>api</artifactId>
         </dependency>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathXmlLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathXmlLoader.java
@@ -63,11 +63,7 @@ public class ClasspathXmlLoader<T> {
             try {
                 try (InputStream is = classLoader.getResourceAsStream(subFolder + File.separator +fileName)) {
                     if (is != null) {
-                        // Read the input stream line by line collecting it into a String
-                        String xml = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
-                                .lines()
-                                .collect(Collectors.joining("\n"));
-                        final T object = JaxbUtils.fromXml(xml, objectClazz);
+                        final T object = JaxbUtils.fromXml(is, objectClazz);
                         allObjects.add(object);
                     }
                 }

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathXmlLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathXmlLoader.java
@@ -28,18 +28,19 @@
 
 package org.opennms.integration.api.xml;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.ByteSource;
 
 public class ClasspathXmlLoader<T> {
     private static final Logger LOG = LoggerFactory.getLogger(ClasspathXmlLoader.class);
@@ -62,13 +63,10 @@ public class ClasspathXmlLoader<T> {
             try {
                 try (InputStream is = classLoader.getResourceAsStream(subFolder + File.separator +fileName)) {
                     if (is != null) {
-                        final ByteSource byteSource = new ByteSource() {
-                            @Override
-                            public InputStream openStream() {
-                                return is;
-                            }
-                        };
-                        final String xml = byteSource.asCharSource(StandardCharsets.UTF_8).read();
+                        // Read the input stream line by line collecting it into a String
+                        String xml = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))
+                                .lines()
+                                .collect(Collectors.joining("\n"));
                         final T object = JaxbUtils.fromXml(xml, objectClazz);
                         allObjects.add(object);
                     }

--- a/config/src/main/java/org/opennms/integration/api/xml/JaxbUtils.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/JaxbUtils.java
@@ -28,10 +28,12 @@
 
 package org.opennms.integration.api.xml;
 
+import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
@@ -56,6 +58,16 @@ class JaxbUtils {
             final Unmarshaller um = context.createUnmarshaller();
             return (V)um.unmarshal(reader);
         } catch(Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static <V> V fromXml(InputStream xml, Class<V> clazz) {
+        try {
+            final JAXBContext context = JAXBContext.newInstance(clazz);
+            final Unmarshaller um = context.createUnmarshaller();
+            return (V) um.unmarshal(xml);
+        } catch (JAXBException ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/Configuration.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/Configuration.java
@@ -42,8 +42,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.opennms.integration.api.xml.ConfigUtils;
 
-import com.google.common.base.Strings;
-
 /**
  * Top-level element for the syslogd-configuration.xml configuration file.
  */
@@ -247,14 +245,14 @@ public class Configuration implements Serializable {
     }
 
     public Optional<TimeZone> getTimeZone(){
-        if(Strings.emptyToNull(this.timeZone) ==null){
+        if (this.timeZone == null || this.timeZone.trim().isEmpty()) {
             return Optional.empty();
         }
         return Optional.of(TimeZone.getTimeZone(ZoneId.of(timeZone)));
     }
 
-    public void setTimeZone(String timeZone){
-        if(Strings.emptyToNull(timeZone) == null ){
+    public void setTimeZone(String timeZone) {
+        if (timeZone == null || timeZone.trim().isEmpty()) {
             this.timeZone = null;
         }
         // test if zone is valid:

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -23,6 +23,10 @@
             <groupId>org.opennms.integration.api</groupId>
             <artifactId>config</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.opennms.integration.api</groupId>


### PR DESCRIPTION
This PR removes Guava as a dependency for the `config` module. It looks like there probably isn't a compelling reason to depend on it right now and it makes depending on the API more difficult in general as Guava is a likely dependency of other code the API will be deployed alongside leading to potential version clashes.

No Jira.