### PR TITLE
NMS-13358: Move Resource Metadata Handling to TS

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/Metric.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/Metric.java
@@ -51,9 +51,25 @@ public interface Metric {
     /** Returns the first tag with the given key. Intrinsic tags are searched first. */
     Tag getFirstTagByKey(String key);
 
+    /**
+     * All intrinsic tags form the composite key of the metric.
+     * Change a value and you get a different metric.
+     */
     Set<Tag> getIntrinsicTags();
 
+    /**
+     * Additional meta data.
+     * Not part of the identity (key).
+     * Meta tags can be used for searches.
+     */
     Set<Tag> getMetaTags();
+
+    /**
+     * Additional meta data.
+     * Not part of the identity (key).
+     * Not searchable.
+     */
+    Set<Tag> getExternalTags();
 
     /** Returns all deterministically concatenated intrinsic tags. */
     String getKey();
@@ -68,11 +84,27 @@ public interface Metric {
         timestamp //  	value represents a unix timestamp. so basically a gauge or counter but we know we can also render the “age” at each point.}
     }
 
-    /** See: https://github.com/metrics20/spec/blob/master/spec.md#glossary */
+    /** See: https://github.com/metrics20/spec/blob/master/spec.md#glossary. */
     enum TagType {
-        /** All intrinsic tags form the composite key of the metric. Change a value and you get a different metric. */
+
+        /**
+         * All intrinsic tags form the composite key of the metric.
+         * Change a value and you get a different metric.
+         */
         intrinsic,
-        /** Additional meta data. Not part of the identity (key). Change a value and you get a different metric. */
-        meta
+
+        /**
+         * Additional meta data.
+         * Not part of the identity (key).
+         * Meta tags can be used for searches.
+         */
+
+        meta,
+        /**
+         * Additional meta data.
+         * Not part of the identity (key).
+         * Not searchable.
+         */
+        external
     }
 }

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
@@ -28,6 +28,7 @@
 
 package org.opennms.integration.api.v1.timeseries.immutables;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -48,15 +49,17 @@ public class ImmutableMetric implements Metric {
     private final String key;
     private final Set<Tag> intrinsicTags;
     private final Set<Tag> metaTags;
+    private final Set<Tag> externalTags;
 
     public ImmutableMetric(final Set<Tag> intrinsicTags) {
-        this(intrinsicTags, new HashSet<>());
+        this(intrinsicTags, new HashSet<>(), new HashSet<>());
     }
 
-    public ImmutableMetric(final Set<Tag> intrinsicTags, final Set<Tag> metaTags) {
-        new MetricValidator(intrinsicTags, metaTags).validate();
+    public ImmutableMetric(final Set<Tag> intrinsicTags, final Set<Tag> metaTags, final Set<Tag> externalTags) {
+        new MetricValidator(intrinsicTags, metaTags, externalTags).validate();
         this.intrinsicTags = ImmutableCollections.newSetOfImmutableType(intrinsicTags);
         this.metaTags = ImmutableCollections.newSetOfImmutableType(metaTags);
+        this.externalTags = ImmutableCollections.newSetOfImmutableType(externalTags);
 
         // create the key out of all tags => they form the composite key
         StringBuilder b = new StringBuilder();
@@ -67,14 +70,14 @@ public class ImmutableMetric implements Metric {
 
     @Override
     public Set<Tag> getTagsByKey(final String key) {
-        return Stream.concat(intrinsicTags.stream(), metaTags.stream())
+        return Stream.concat(Stream.concat(intrinsicTags.stream(), metaTags.stream()), externalTags.stream())
                 .filter(t -> Objects.equals(t.getKey(), key))
                 .collect(Collectors.toSet());
     }
 
     @Override
     public Tag getFirstTagByKey(final String key) {
-        List<Tag> tags = Stream.concat(intrinsicTags.stream(), metaTags.stream())
+        List<Tag> tags = Stream.concat(Stream.concat(intrinsicTags.stream(), metaTags.stream()), externalTags.stream())
                 .filter(t -> Objects.equals(t.getKey(), key))
                 .collect(Collectors.toList());
         return (tags.size() > 0) ? tags.get(0) : null;
@@ -93,6 +96,11 @@ public class ImmutableMetric implements Metric {
 
     @Override
     public Set<Tag> getMetaTags() {
+        return metaTags;
+    }
+
+    @Override
+    public Set<Tag> getExternalTags() {
         return metaTags;
     }
 
@@ -117,6 +125,7 @@ public class ImmutableMetric implements Metric {
                 .add("key='" + key + "'")
                 .add("tags=" + intrinsicTags)
                 .add("metaTags=" + metaTags)
+                .add("externalTags=" + externalTags)
                 .toString();
     }
 
@@ -127,9 +136,15 @@ public class ImmutableMetric implements Metric {
     public final static class MetricBuilder {
         private final Set<Tag> intrinsicTags = new HashSet<>();
         private final Set<Tag> metaTags = new HashSet<>();
+        private final Set<Tag> externalTags = new HashSet<>();
 
         public MetricBuilder intrinsicTag(Tag tag) {
             this.intrinsicTags.add(tag);
+            return this;
+        }
+
+        public MetricBuilder intrinsicTags(Collection<Tag> tags) {
+            this.intrinsicTags.addAll(tags);
             return this;
         }
 
@@ -146,6 +161,11 @@ public class ImmutableMetric implements Metric {
             return this;
         }
 
+        public MetricBuilder metaTags(Collection<Tag> tags) {
+            this.metaTags.addAll(tags);
+            return this;
+        }
+
         public MetricBuilder metaTag(String key, String value) {
             return this.metaTag(new ImmutableTag(key, value));
         }
@@ -154,8 +174,26 @@ public class ImmutableMetric implements Metric {
             return this.metaTag(new ImmutableTag(value));
         }
 
+        public MetricBuilder externalTag(Tag tag) {
+            this.metaTags.add(tag);
+            return this;
+        }
+
+        public MetricBuilder externalTags(Collection<Tag> tags) {
+            this.metaTags.addAll(tags);
+            return this;
+        }
+
+        public MetricBuilder externalTag(String key, String value) {
+            return this.metaTag(new ImmutableTag(key, value));
+        }
+
+        public MetricBuilder externalTag(String value) {
+            return this.metaTag(new ImmutableTag(value));
+        }
+
         public ImmutableMetric build() {
-            return new ImmutableMetric(this.intrinsicTags, this.metaTags);
+            return new ImmutableMetric(this.intrinsicTags, this.metaTags, this.externalTags);
         }
     }
 

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
@@ -180,16 +180,16 @@ public class ImmutableMetric implements Metric {
         }
 
         public MetricBuilder externalTags(Collection<Tag> tags) {
-            this.metaTags.addAll(tags);
+            this.externalTags.addAll(tags);
             return this;
         }
 
         public MetricBuilder externalTag(String key, String value) {
-            return this.metaTag(new ImmutableTag(key, value));
+            return this.externalTag(new ImmutableTag(key, value));
         }
 
         public MetricBuilder externalTag(String value) {
-            return this.metaTag(new ImmutableTag(value));
+            return this.externalTag(new ImmutableTag(value));
         }
 
         public ImmutableMetric build() {

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
@@ -43,7 +43,7 @@ public class ImmutableTag implements Tag {
 
     public ImmutableTag(String key, String value) {
         this.key = key;
-        this.value = Objects.requireNonNull(value);
+        this.value = Objects.requireNonNull(value, key); // we use the key as NullpointerException message since it's cheap.
     }
 
     public ImmutableTag(String value) {

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
@@ -43,7 +43,7 @@ public class ImmutableTag implements Tag {
 
     public ImmutableTag(String key, String value) {
         this.key = key;
-        this.value = Objects.requireNonNull(value, key);
+        this.value = Objects.requireNonNull(value);
     }
 
     public ImmutableTag(String value) {

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/MetricValidator.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/MetricValidator.java
@@ -38,10 +38,12 @@ class MetricValidator {
 
     private final Set<Tag> intrinsicTags;
     private final Set<Tag> metaTags;
+    private final Set<Tag> externalTags;
 
-    public MetricValidator(final Set<Tag> intrinsicTags, final Set<Tag> metaTags) {
+    public MetricValidator(final Set<Tag> intrinsicTags, final Set<Tag> metaTags, final Set<Tag> externalTags) {
         this.intrinsicTags = intrinsicTags;
         this.metaTags = metaTags;
+        this.externalTags = externalTags;
     }
 
     public Set<Tag> getTagsByKey(final String key) {
@@ -56,6 +58,7 @@ class MetricValidator {
     private void requireNonNullTagSets() {
         Objects.requireNonNull(intrinsicTags);
         Objects.requireNonNull(metaTags);
+        Objects.requireNonNull(externalTags);
     }
 
     private void requireAtLeastOneIntrinsicTagToBePresent() {

--- a/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/AbstractStorageIntegrationTest.java
+++ b/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/AbstractStorageIntegrationTest.java
@@ -194,7 +194,7 @@ public abstract class AbstractStorageIntegrationTest {
                 .build();
     }
 
-    private static List<Metric> createMetrics() {
+    protected static List<Metric> createMetrics() {
         final String uuid = UUID.randomUUID().toString().replaceAll("-", "");
         List<Metric> metrics = new ArrayList<>();
         for(int i=1; i<5; i++) {
@@ -203,7 +203,7 @@ public abstract class AbstractStorageIntegrationTest {
         return metrics;
     }
 
-    private static Metric createMetric(final String uuid, final int nodeId) {
+    protected static Metric createMetric(final String uuid, final int nodeId) {
         String mtype = (nodeId % 2 == 0) ? Metric.Mtype.gauge.name() : Metric.Mtype.counter.name();
         return ImmutableMetric.builder()
                 .intrinsicTag("name", "n" + uuid) // make sure the name starts with a letter and not a number


### PR DESCRIPTION
This PR introduces another type of Metric tag: external. We use it for tags that can not be searched.

https://issues.opennms.org/browse/NMS-13358