### PR TITLE
NMS-13357: Use RE2 for regular expression matching and syntax.

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/TagMatcher.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/TagMatcher.java
@@ -30,17 +30,20 @@ package org.opennms.integration.api.v1.timeseries;
 
 /**
  * A TagMatcher is used to search for Metrics.
+ *
  * A TagMatcher works in the following way:
- * The key defines to which Tags it can be applied. All Tags that have the same key as the TagMatcher are evaluated.
- * The value of a Tag is evaluated against the value of a TagMatcher.
- * The comparison is defined by the Type.
+ *   The key defines to which Tags it can be applied. All Tags that have the same key as the TagMatcher are evaluated.
+ *   The value of a Tag is evaluated against the value of a TagMatcher.
+ *   The comparison is defined by the Type.
+ *
+ * Regular expression must use the RE2 syntax: https://github.com/google/re2/wiki/Syntax
  *
  * Examples:
- * Tag(myKey, myValue) applied to TagMatcher(equals,    myOtherKey, myValue) is no match
- * Tag(myKey, myValue) applied to TagMatcher(notEquals, myOtherKey, myValue) is no match
- * Tag(myKey, myValue) applied to TagMatcher(equals,    myKey, myValue)      is a match
- * Tag(myKey, myValue) applied to TagMatcher(equals,    myKey, myOtherValue) is no match
- * Tag(myKey, myValue) applied to TagMatcher(notEquals, myKey, myOtherValue) is a match
+ *   Tag(myKey, myValue) applied to TagMatcher(EQUALS,    myOtherKey, myValue) is no match
+ *   Tag(myKey, myValue) applied to TagMatcher(NOT_EQUALS, myOtherKey, myValue) is no match
+ *   Tag(myKey, myValue) applied to TagMatcher(EQUALS,    myKey, myValue)      is a match
+ *   Tag(myKey, myValue) applied to TagMatcher(EQUALS,    myKey, myOtherValue) is no match
+ *   Tag(myKey, myValue) applied to TagMatcher(NOT_EQUALS, myKey, myOtherValue) is a match
  */
 public interface TagMatcher {
     enum Type {

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <guava.version>26.0-jre</guava.version>
         <karaf.version>4.1.5</karaf.version>
         <log4j.version>2.13.3</log4j.version>
+        <re2j.version>1.6</re2j.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
     </properties>
 
@@ -64,6 +65,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.re2j</groupId>
+                <artifactId>re2j</artifactId>
+                <version>${re2j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.opennms.integration.api</groupId>

--- a/test-suites/tss-tests/pom.xml
+++ b/test-suites/tss-tests/pom.xml
@@ -17,6 +17,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.re2j</groupId>
+            <artifactId>re2j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/InMemoryStorage.java
+++ b/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/InMemoryStorage.java
@@ -38,6 +38,9 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
+
+import com.google.re2j.Pattern;
+
 /**
  * Simulates a TimeSeriesStorage in memory (HashMap). The implementation is super simple and not very efficient.
  * For testing and evaluating purposes only, not for production.
@@ -96,9 +99,9 @@ public class InMemoryStorage implements TimeSeriesStorage {
         } else if (TagMatcher.Type.NOT_EQUALS == matcher.getType()) {
             return !tag.getValue().equals(matcher.getValue());
         } else if (TagMatcher.Type.EQUALS_REGEX == matcher.getType()) {
-            return tag.getValue().matches(matcher.getValue());
+            return Pattern.matches(matcher.getValue(), tag.getValue());
         } else if (TagMatcher.Type.NOT_EQUALS_REGEX == matcher.getType()) {
-            return !tag.getValue().matches(matcher.getValue());
+            return !Pattern.matches(matcher.getValue(), tag.getValue());
         } else {
             throw new IllegalArgumentException("Implement me for " + matcher.getType());
         }


### PR DESCRIPTION
Use RE2 syntax for regular expressions and evaluations.

InfluxDB and Prometheus both support RE2 for example, and there are bindings available for multiple languages.