### PR TITLE
NMS-13782: remove InterfaceToNodeCache.getNodeIds

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>api</artifactId>

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/InterfaceToNodeCache.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/InterfaceToNodeCache.java
@@ -30,7 +30,6 @@ package org.opennms.integration.api.v1.dao;
 
 import java.net.InetAddress;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.opennms.integration.api.v1.annotations.Consumable;
 
@@ -41,13 +40,6 @@ import org.opennms.integration.api.v1.annotations.Consumable;
  */
 @Consumable
 public interface InterfaceToNodeCache {
-
-    /**
-     * @param location location or null if Default
-     * @param ipAddr IP address to match
-     * @return node ids, primary interfaces will be first
-     */
-    Stream<Integer> getNodeIds(String location, InetAddress ipAddr);
 
     /**
      * @param location location or null if Default

--- a/archetypes/example-kar-plugin/pom.xml
+++ b/archetypes/example-kar-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>archetypes</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>example-kar-plugin</artifactId>
     <packaging>maven-archetype</packaging>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>archetypes</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>common</artifactId>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>config</artifactId>

--- a/karaf-features/pom.xml
+++ b/karaf-features/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>karaf-features</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.opennms.integration.api</groupId>
     <artifactId>api-project</artifactId>
     <packaging>pom</packaging>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
     <name>OpenNMS Integration API :: Parent</name>
     <url>https://github.com/OpenNMS/opennms-integration-api</url>
     <description>Integration and extension API for OpenNMS</description>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.integration.api.sample</groupId>

--- a/test-api/pom.xml
+++ b/test-api/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>test-api</artifactId>

--- a/test-suites/pom.xml
+++ b/test-suites/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>test-suites</artifactId>

--- a/test-suites/tss-tests/pom.xml
+++ b/test-suites/tss-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>test-suites</artifactId>
-        <version>0.7.0-SNAPSHOT</version>
+        <version>0.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tss-tests</artifactId>


### PR DESCRIPTION
Issue: https://github.com/OpenNMS/opennms/pull/3921

Removes an unused method that raised some implementation issues.