### PR TITLE
DC-126: Deduplicate the metric on the query results

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/DataPoint.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/DataPoint.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2020 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.timeseries;
+
+import java.time.Instant;
+
+/** A value at a specific time for a specific metric. */
+public interface DataPoint {
+
+    Instant getTime();
+
+    Double getValue();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/TimeSeriesData.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/TimeSeriesData.java
@@ -1,0 +1,14 @@
+package org.opennms.integration.api.v1.timeseries;
+
+import java.util.List;
+
+/** The return value for a TimeSeriesFetchRequest. */
+public interface TimeSeriesData {
+
+    /** The full metric with all tags (not only intrinsic tags). */
+    Metric getMetric();
+
+    /** DataPoints for the queried metric and time range. */
+    List<DataPoint> getDataPoints();
+
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableDataPoint.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableDataPoint.java
@@ -1,0 +1,82 @@
+package org.opennms.integration.api.v1.timeseries.immutables;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+import org.opennms.integration.api.v1.timeseries.DataPoint;
+import org.opennms.integration.api.v1.timeseries.Sample;
+
+public class ImmutableDataPoint implements DataPoint {
+
+    private final Instant time;
+    private final Double value;
+
+    public ImmutableDataPoint(Instant time, Double value) {
+        this.time = Objects.requireNonNull(time);
+        this.value = Objects.requireNonNull(value);
+    }
+
+    public Instant getTime() {
+        return this.time;
+    }
+
+    public Double getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Sample)) return false;
+        Sample that = (Sample) o;
+        return Objects.equals(time, that.getTime()) &&
+                Objects.equals(value, that.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(time, value);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", this.getClass().getSimpleName() + "[", "]")
+                .add("time=" + time)
+                .add("value=" + value)
+                .toString();
+    }
+
+    public static ImmutableDataPointBuilder builder() {
+        return new ImmutableDataPointBuilder();
+    }
+
+    public static class ImmutableDataPointBuilder {
+        private Instant time;
+        private Double value;
+
+        private ImmutableDataPointBuilder() {
+        }
+
+        public ImmutableDataPointBuilder time(Instant time) {
+            this.time = time;
+            return this;
+        }
+
+        public ImmutableDataPointBuilder value(Double value) {
+            this.value = value;
+            return this;
+        }
+
+        public ImmutableDataPoint build() {
+            return new ImmutableDataPoint(time, value);
+        }
+
+        public String toString() {
+            return new StringJoiner(", ", this.getClass().getSimpleName() + "{", "}")
+                    .add("time=" + time)
+                    .add("value=" + value)
+                    .toString();
+        }
+    }
+}

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTimeSeriesData.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTimeSeriesData.java
@@ -1,0 +1,95 @@
+package org.opennms.integration.api.v1.timeseries.immutables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+import org.opennms.integration.api.v1.timeseries.DataPoint;
+import org.opennms.integration.api.v1.timeseries.Metric;
+import org.opennms.integration.api.v1.timeseries.TimeSeriesData;
+
+public class ImmutableTimeSeriesData implements TimeSeriesData {
+
+    private final Metric metric;
+    private final List<DataPoint> dataPoints;
+
+    public ImmutableTimeSeriesData(final Metric metric, final List<DataPoint> dataPoints) {
+        this.metric = Objects.requireNonNull(metric);
+        this.dataPoints = Objects.requireNonNull(dataPoints);
+    }
+
+    @Override
+    public Metric getMetric() {
+        return this.metric;
+    }
+
+    @Override
+    public List<DataPoint> getDataPoints() {
+        return this.dataPoints;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableTimeSeriesData that = (ImmutableTimeSeriesData) o;
+        return Objects.equals(metric, that.metric) && Objects.equals(dataPoints, that.dataPoints);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(metric, dataPoints);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", this.getClass().getSimpleName() + "{", "}")
+                .add("metric=" + metric)
+                .add("dataPoints=" + dataPoints)
+                .toString();
+    }
+
+    public static ImmutableTimeSeriesDataBuilder builder() {
+        return new ImmutableTimeSeriesDataBuilder();
+    }
+
+    public static class ImmutableTimeSeriesDataBuilder {
+        private Metric metric;
+        List<DataPoint> dataPoints;
+
+        private ImmutableTimeSeriesDataBuilder() {
+        }
+
+        public ImmutableTimeSeriesDataBuilder metric(final Metric metric) {
+            this.metric = metric;
+            return this;
+        }
+
+        public ImmutableTimeSeriesDataBuilder dataPoints(final List<DataPoint> dataPoints) {
+            this.dataPoints = dataPoints;
+            return this;
+        }
+
+        public ImmutableTimeSeriesDataBuilder dataPoint(final DataPoint dataPoint) {
+            Objects.requireNonNull(dataPoint);
+            if(this.dataPoints == null) {
+                this.dataPoints = new ArrayList<>();
+            }
+            this.dataPoints.add(dataPoint);
+            return this;
+        }
+
+        public ImmutableTimeSeriesData build() {
+            return new ImmutableTimeSeriesData(metric, dataPoints);
+        }
+
+        @Override
+        public String toString() {
+            return new StringJoiner(", ", this.getClass().getSimpleName() + "{", "}")
+                    .add("metric=" + metric)
+                    .add("dataPoints=" + dataPoints)
+                    .toString();
+        }
+    }
+}


### PR DESCRIPTION
_TimeSeriesStorage.getTimeseries(TimeSeriesFetchRequest request)_ returns a List of Samples.
Each Sample contains the same Metric Object.
This PR deduplicates that and returns only one Metric per getTimeseries request.

Jira: https://issues.opennms.org/browse/DC-126