### PR TITLE
OIA-42: Remove dev mode flag on yarn preview

### DIFF
--- a/ui-extension/package.json
+++ b/ui-extension/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "dev": "vite --config vite.config.dev.ts",
     "build": "vue-tsc --noEmit && vite build",
-    "preview": "vite build --mode development && vite preview --port 5002"
+    "preview": "vite build && vite preview --port 5002"
   },
   "dependencies": {
     "pinia": "^2.0.14",


### PR DESCRIPTION
Flag was used when testing environment variables in a local dev setup. Should not have been merged here.