### PR TITLE
DC-266: Provide systemId and environmentId in OIA

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/info/DatetimeformatConfig.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/DatetimeformatConfig.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.info;
+
+import java.time.ZoneId;
+
+public interface DatetimeformatConfig {
+    ZoneId getZoneId();
+    String getDatetimeformat();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/info/DatetimeformatConfig.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/DatetimeformatConfig.java
@@ -30,6 +30,9 @@ package org.opennms.integration.api.v1.info;
 
 import java.time.ZoneId;
 
+import org.opennms.integration.api.v1.annotations.Model;
+
+@Model
 public interface DatetimeformatConfig {
     ZoneId getZoneId();
     String getDatetimeformat();

--- a/api/src/main/java/org/opennms/integration/api/v1/info/InfoService.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/InfoService.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.info;
+
+import org.opennms.integration.api.v1.annotations.Consumable;
+
+/** Provides information about OpenNMS to plugins. */
+@Consumable
+public interface InfoService {
+    Information get();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/info/Information.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/Information.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.info;
+
+import java.util.Map;
+
+import org.opennms.integration.api.v1.annotations.Model;
+
+@Model
+public interface Information {
+
+    // Copied from: org.opennms.web.rest.v1.InfoDTO
+    // TODO: Patrick: discuss with core team if we need all these attributes in OIA?
+    DatetimeformatConfig getDatetimeformatConfig();
+    String getDisplayVersion();
+    String getVersion();
+    String getPackageName();
+    String getPackageDescription();
+    TicketerConfig getTicketerConfig();
+    Map<String,String> getServices();
+
+    /** Uniquely identifies this OpenNMS instance.  */
+    String getSystemId();
+
+    /** Uniquely identifies a OpenNMS environment.
+     * It may consist of a main OpenNMS instance and multiple minions. */
+    String getEnvironmentId();
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/info/Information.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/Information.java
@@ -45,7 +45,7 @@ public interface Information {
     TicketerConfig getTicketerConfig();
     Map<String,String> getServices();
 
-    /** Uniquely identifies this OpenNMS instance.  */
+    /** Uniquely identifies this OpenNMS instance. */
     String getSystemId();
 
     /** Uniquely identifies a OpenNMS environment.

--- a/api/src/main/java/org/opennms/integration/api/v1/info/README.md
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/README.md
@@ -1,0 +1,2 @@
+# Info Service
+This package exposes internal OpenNMS information in a defined way to plugins.

--- a/api/src/main/java/org/opennms/integration/api/v1/info/TicketerConfig.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/TicketerConfig.java
@@ -28,6 +28,9 @@
 
 package org.opennms.integration.api.v1.info;
 
+import org.opennms.integration.api.v1.annotations.Model;
+
+@Model
 public interface TicketerConfig {
     /**
      * The plugin currently in use. If enabled is false, this should be null.

--- a/api/src/main/java/org/opennms/integration/api/v1/info/TicketerConfig.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/info/TicketerConfig.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.info;
+
+public interface TicketerConfig {
+    /**
+     * The plugin currently in use. If enabled is false, this should be null.
+     */
+    String getPlugin();
+    boolean isEnabled();
+}


### PR DESCRIPTION
This PR exposes a systemId and an environmentId via OIA:

- SystemId: Unique identifier of a OpenNMS instance (main or minion)
- EnvironmentId: Unique identifier of a set of OpenNMS instances that are connected (one main instance plus minions)

This PR is so far experimental and looking for input. After talking to @RangerRick, I took the rest DTO class [org.opennms.web.rest.v1.InfoDTO](https://github.com/OpenNMS/opennms/blob/release-30.x/opennms-webapp-rest/src/main/java/org/opennms/web/rest/v1/InfoDTO.java) and converted it into a OIA interface.

I'm looking for input:

1. is this the desired approach?
2. do we want the same attributes exposed as in _org.opennms.web.rest.v1.InfoDTO_? For my use case I only need systemId and environmentId.

The PR is not feature complete. We are missing the implementation of the model classes. For now its just a base for discussion.
