### PR TITLE
add IPLike (and InetAddressUtils) to OPA

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>api</artifactId>

--- a/archetypes/example-kar-plugin/pom.xml
+++ b/archetypes/example-kar-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>archetypes</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>example-kar-plugin</artifactId>
     <packaging>maven-archetype</packaging>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>archetypes</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>common</artifactId>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIPAddress.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIPAddress.java
@@ -1,0 +1,451 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2014-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.model.immutables;
+
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ImmutableIPAddress implements Comparable<ImmutableIPAddress> {
+    private static final Pattern LEADING_ZEROS = Pattern.compile("^0:[0:]+");
+    protected final InetAddress m_inetAddress;
+
+    public ImmutableIPAddress(final ImmutableIPAddress addr) {
+        m_inetAddress = addr.m_inetAddress;
+    }
+
+    public ImmutableIPAddress(final String dottedNotation) {
+        m_inetAddress = getInetAddress(dottedNotation);
+    }
+
+    public ImmutableIPAddress(final InetAddress inetAddress) {
+        m_inetAddress = inetAddress;
+    }
+
+    public ImmutableIPAddress(final byte[] ipAddrOctets) {
+        try {
+            m_inetAddress = InetAddress.getByAddress(ipAddrOctets);
+        } catch (final UnknownHostException e) {
+            throw new IllegalArgumentException("Cannot convert bytes to an InetAddress.", e);
+        }
+    }
+
+    public static ImmutableIPAddress min(final ImmutableIPAddress a, final ImmutableIPAddress b) {
+        return (a.isLessThan(b) ? a : b);
+    }
+
+    public InetAddress toInetAddress() {
+        try {
+            return InetAddress.getByAddress(m_inetAddress.getHostName(), m_inetAddress.getAddress());
+        } catch (final UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public byte[] toOctets() {
+        final var address = m_inetAddress.getAddress();
+        return Arrays.copyOf(address, address.length);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj instanceof ImmutableIPAddress) {
+            return Arrays.equals(m_inetAddress.getAddress(), ((ImmutableIPAddress) obj).m_inetAddress.getAddress());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return m_inetAddress.hashCode();
+    }
+
+    @Override
+    public int compareTo(final ImmutableIPAddress o) {
+        return compare(m_inetAddress.getAddress(), o.m_inetAddress.getAddress());
+    }
+
+    @SuppressWarnings("java:S106")
+    public String toUserString() {
+        if (m_inetAddress instanceof Inet4Address) {
+            return toIpAddrString(m_inetAddress);
+        } else if (m_inetAddress instanceof Inet6Address) {
+            /*
+             * <p>From: <a href="https://code.google.com/p/guava-libraries/source/browse/guava/src/com/google/common/primitives/Ints.java">Guava</a>.</p>
+             */
+            final byte[] bytes = m_inetAddress.getAddress();
+            final int[] hextets = new int[8];
+            for (int i = 0; i < hextets.length; i++) {
+                hextets[i] = fromBytes(
+                    (byte) 0,
+                    (byte) 0,
+                    bytes[2 * i],
+                    bytes[2 * i + 1]
+                );
+            }
+            compressLongestRunOfZeroes(hextets);
+            return hextetsToIPv6String(hextets);
+        } else {
+            System.err.println("Not an Inet4Address nor an Inet6Address! " + m_inetAddress.getClass());
+            return m_inetAddress.getHostAddress();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return toUserString();
+    }
+
+    public String toDbString() {
+        return toIpAddrString(m_inetAddress);
+    }
+
+    /** {@inheritDoc} */
+    public BigInteger toBigInteger() {
+        return new BigInteger(1, m_inetAddress.getAddress());
+    }
+
+    /**
+     * Increment this IP address.
+     *
+     * @return the new IP address
+     * @throws IllegalStateException if it overflows
+     */
+    public ImmutableIPAddress incr() {
+        final byte[] current = m_inetAddress.getAddress();
+        final byte[] b = new byte[current.length];
+
+        int carry = 1;
+        for(int i = current.length-1; i >= 0; i--) {
+            b[i] = (byte)(current[i] + carry);
+            // if overflow we need to carry to the next byte
+            carry = b[i] == 0 ? carry : 0;
+        }
+
+        if (carry > 0) {
+            // we have overflowed the address
+            throw new IllegalStateException("you have tried to increment the max ip address");
+        }
+
+        return new ImmutableIPAddress(b);
+    }
+
+    /**
+     * Decrement this IP address.
+     *
+     * @return the new IP address
+     * @throws IllegalStateException if it underflows
+     */
+    public ImmutableIPAddress decr() {
+        final byte[] current = m_inetAddress.getAddress();
+        final byte[] b = new byte[current.length];
+
+        int borrow = 1;
+        for(int i = current.length-1; i >= 0; i--) {
+            b[i] = (byte)(current[i] - borrow);
+            // if underflow then we need to borrow from the next byte
+            borrow = b[i] == (byte)0xff ? borrow : 0;
+        }
+
+        if (borrow > 0) {
+            // we have underflowed the address
+            throw new IllegalStateException("you have tried to decrement the '0' ip address");
+        }
+
+        return new ImmutableIPAddress(b);
+
+    }
+
+    /**
+     * Check if this IP address is immediately before the provided IP address.
+     *
+     * @param other the address to check against
+     * @return a boolean
+     */
+    public boolean isPredecessorOf(final ImmutableIPAddress other) {
+        return other.decr().equals(this);
+    }
+
+    /**
+     * Check if this IP address is immediately after the provided IP address.
+     *
+     * @param other the address to check against
+     * @return a boolean
+     */
+    public boolean isSuccessorOf(final ImmutableIPAddress other) {
+        return other.incr().equals(this);
+    }
+
+    /**
+     * Check if this IP address is smaller than the provided IP address.
+     *
+     * @param other the address to check against
+     * @return a boolean
+     */
+    public boolean isLessThan(final ImmutableIPAddress other) {
+        return compareTo(other) < 0;
+    }
+
+    /**
+     * Check if this IP address is smaller or equal to the provided IP address.
+     *
+     * @param other the address to check against
+     * @return a boolean
+     */
+    public boolean isLessThanOrEqualTo(final ImmutableIPAddress other) {
+        return compareTo(other) <= 0;
+    }
+
+    /**
+     * Check if this IP address is larger than the provided IP address.
+     *
+     * @param other the address to check against
+     * @return a boolean
+     */
+    public boolean isGreaterThan(final ImmutableIPAddress other) {
+        return compareTo(other) > 0;
+    }
+
+    /**
+     * Check if this IP address is larger or equal to the provided IP address.
+     *
+     * @param other the address to check against
+     * @return a boolean
+     */
+    public boolean isGreaterThanOrEqualTo(final ImmutableIPAddress other) {
+        return compareTo(other) >= 0;
+    }
+
+    /**
+     * Return the larger of two IP addresses.
+     */
+    public static ImmutableIPAddress max(final ImmutableIPAddress a, final ImmutableIPAddress b) {
+        return (a.isGreaterThan(b) ? a : b);
+    }
+
+    protected String toIpAddrString(final InetAddress addr) {
+        if (addr == null) {
+            throw new IllegalArgumentException("Cannot convert null InetAddress to a string");
+        } else {
+            final byte[] address = addr.getAddress();
+            if (address == null) {
+                // This case can occur when Jersey uses Spring bean classes which use
+                // CGLIB bytecode manipulation to generate InetAddress classes. This will
+                // occur during REST calls.
+                //
+                throw new IllegalArgumentException("InetAddress instance violates contract by returning a null address from getAddress()");
+            } else if (addr instanceof Inet4Address) {
+                return toIpAddrString(address);
+            } else if (addr instanceof Inet6Address) {
+                final Inet6Address addr6 = (Inet6Address)addr;
+                final StringBuilder sb = new StringBuilder(toIpAddrString(address));
+                if (addr6.getScopeId() != 0) {
+                    sb.append("%").append(addr6.getScopeId());
+                }
+                return sb.toString();
+            } else {
+                throw new IllegalArgumentException("Unknown type of InetAddress: " + addr.getClass().getName());
+            }
+        }
+    }
+
+    protected String toIpAddrString(final byte[] addr) {
+        if (addr.length == 4) {
+            return getInetAddress(addr).getHostAddress();
+        } else if (addr.length == 16) {
+            return String.format("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+                                 addr[0],
+                                 addr[1],
+                                 addr[2],
+                                 addr[3],
+                                 addr[4],
+                                 addr[5],
+                                 addr[6],
+                                 addr[7],
+                                 addr[8],
+                                 addr[9],
+                                 addr[10],
+                                 addr[11],
+                                 addr[12],
+                                 addr[13],
+                                 addr[14],
+                                 addr[15]
+                    );
+        } else {
+            throw new IllegalArgumentException("IP address has an illegal number of bytes: " + addr.length);
+        }
+    }
+
+    protected byte[] toIpAddrBytes(final String dottedNotation) {
+        final var inetAddress = getInetAddress(dottedNotation);
+        if (inetAddress == null) {
+            throw new IllegalArgumentException("Invalid IP Address " + dottedNotation);
+        }
+        return inetAddress.getAddress();
+    }
+
+    private InetAddress getInetAddress(final byte[] ipAddrOctets) {
+        try {
+            return InetAddress.getByAddress(ipAddrOctets);
+        } catch (final UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP Address " + Arrays.toString(ipAddrOctets) + " with length " + ipAddrOctets.length);
+        }
+
+    }
+
+    private InetAddress getInetAddress(final String dottedNotation) {
+        try {
+            return dottedNotation == null? null : InetAddress.getByName(dottedNotation);
+        } catch (final UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid IP Address " + dottedNotation);
+        }
+    }
+
+    @SuppressWarnings("java:S3776")
+    private int compare(final byte[] a, final byte[] b) {
+        if (a == null && b == null) {
+            return 0;
+        } else if (a == null) {
+            return -1;
+        } else if (b == null) {
+            return 1;
+        } else {
+            // Make shorter byte arrays "less than" longer arrays
+            if (a.length < b.length) {
+                return -1;
+            } else if (a.length > b.length) {
+                return 1;
+            } else {
+                // Compare byte-by-byte
+                for (int i = 0; i < a.length; i++) {
+                    final int aInt = unsignedByteToInt(a[i]);
+                    final int bInt = unsignedByteToInt(b[i]);
+                    if (aInt < bInt) {
+                        return -1;
+                    } else if (aInt > bInt) {
+                        return 1;
+                    }
+                }
+                // OK both arrays are the same length and every byte is identical so they are equal
+                return 0;
+            }
+        }
+    }
+
+    /**
+     * Returns the {@code int} value whose byte representation is the given 4
+     * bytes, in big-endian order; equivalent to {@code Ints.fromByteArray(new
+     * byte[] {b1, b2, b3, b4})}.
+     *
+     * <p>From: <a href="https://code.google.com/p/guava-libraries/source/browse/guava/src/com/google/common/primitives/Ints.java">Guava</a>.</p>
+     */
+    public static int fromBytes(final byte b1, final byte b2, final byte b3, final byte b4) {
+      return b1 << 24 | (b2 & 0xFF) << 16 | (b3 & 0xFF) << 8 | (b4 & 0xFF);
+    }
+
+    /**
+     * Identify and mark the longest run of zeroes in an IPv6 address.
+     *
+     * <p>Only runs of two or more hextets are considered.  In case of a tie, the
+     * leftmost run wins.  If a qualifying run is found, its hextets are replaced
+     * by the sentinel value -1.
+     *
+     * <p>From: <a href="https://code.google.com/p/guava-libraries/source/browse/guava/src/com/google/common/primitives/Ints.java">Guava</a>.</p>
+     *
+     * @param hextets {@code int[]} mutable array of eight 16-bit hextets
+     */
+    private static void compressLongestRunOfZeroes(final int[] hextets) {
+        int bestRunStart = -1;
+        int bestRunLength = -1;
+        int runStart = -1;
+        for (int i = 0; i < hextets.length + 1; i++) {
+            if (i < hextets.length && hextets[i] == 0) {
+                if (runStart < 0) {
+                    runStart = i;
+                }
+            } else if (runStart >= 0) {
+                int runLength = i - runStart;
+                if (runLength > bestRunLength) {
+                    bestRunStart = runStart;
+                    bestRunLength = runLength;
+                }
+                runStart = -1;
+            }
+        }
+        if (bestRunLength >= 2) {
+            Arrays.fill(hextets, bestRunStart, bestRunStart + bestRunLength, -1);
+        }
+    }
+
+    /**
+     * Convert a list of hextets into a human-readable IPv6 address.
+     *
+     * <p>In order for "::" compression to work, the input should contain negative
+     * sentinel values in place of the elided zeroes.<p>
+     *
+     * <p>From: <a href="https://code.google.com/p/guava-libraries/source/browse/guava/src/com/google/common/primitives/Ints.java">Guava</a>.</p>
+     *
+     * @param hextets {@code int[]} array of eight 16-bit hextets, or -1s
+     */
+    private static String hextetsToIPv6String(final int[] hextets) {
+        /*
+         * While scanning the array, handle these state transitions:
+         *   start->num => "num"     start->gap => "::"
+         *   num->num   => ":num"    num->gap   => "::"
+         *   gap->num   => "num"     gap->gap   => ""
+         */
+        final StringBuilder buf = new StringBuilder(39);
+        boolean lastWasNumber = false;
+        for (int i = 0; i < hextets.length; i++) {
+            final boolean thisIsNumber = hextets[i] >= 0;
+            if (thisIsNumber) {
+                if (lastWasNumber) {
+                    buf.append(':');
+                }
+                buf.append(Integer.toHexString(hextets[i]));
+            } else {
+                if (i == 0 || lastWasNumber) {
+                    buf.append("::");
+                }
+            }
+            lastWasNumber = thisIsNumber;
+        }
+        final Matcher matcher = LEADING_ZEROS.matcher(buf.toString());
+        return matcher.replaceAll(":");
+    }
+
+    private int unsignedByteToInt(final byte b) {
+        return b < 0 ? ((int)b)+256 : ((int)b);
+    }
+}

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>config</artifactId>

--- a/karaf-features/pom.xml
+++ b/karaf-features/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>karaf-features</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>api</module>
         <module>archetypes</module>
         <module>common</module>
+        <module>utils</module>
         <module>karaf-features</module>
         <module>sample</module>
         <module>test-api</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.opennms.integration.api</groupId>
     <artifactId>api-project</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.1-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <name>OpenNMS Integration API :: Parent</name>
     <url>https://github.com/OpenNMS/opennms-integration-api</url>
     <description>Integration and extension API for OpenNMS</description>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.opennms.integration.api.sample</groupId>

--- a/test-api/pom.xml
+++ b/test-api/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>test-api</artifactId>

--- a/test-suites/pom.xml
+++ b/test-suites/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>api-project</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>test-suites</artifactId>

--- a/test-suites/tss-tests/pom.xml
+++ b/test-suites/tss-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.opennms.integration.api</groupId>
         <artifactId>test-suites</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tss-tests</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.opennms.integration.api</groupId>
+        <artifactId>api-project</artifactId>
+        <version>1.6.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.opennms.integration.api.utils</artifactId>
+    <name>OpenNMS Integration API :: Utils</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opennms.integration.api</groupId>
+            <artifactId>api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.integration.api</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/utils/src/main/java/org/opennms/integration/api/utils/ByteArrayComparator.java
+++ b/utils/src/main/java/org/opennms/integration/api/utils/ByteArrayComparator.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2010-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.utils;
+
+import java.util.Comparator;
+
+/**
+ * Comparator that is used to compare byte arrays. This should be used to compare
+ * IP addresses using {@link java.net.InetAddress#getAddress()} and can be used to
+ * compare any pair of IPv4 and/or IPv6 addresses.
+ *
+ * @author Seth &lt;seth@opennms.org&gt;
+ */
+public class ByteArrayComparator implements Comparator<byte[]> {
+
+    @Override
+    public int compare(final byte[] a, final byte[] b) {
+        if (a == null && b == null) {
+            return 0;
+        } else if (a == null) {
+            return -1;
+        } else if (b == null) {
+            return 1;
+        } else {
+            // Make shorter byte arrays "less than" longer arrays
+            final int comparison = Integer.compare(a.length, b.length);
+            if (comparison != 0) {
+                return comparison;
+            } else {
+                // Compare byte-by-byte
+                for (int i = 0; i < a.length; i++) {
+                    final int byteComparison = Integer.compare(unsignedByteToInt(a[i]), unsignedByteToInt(b[i]));
+                    if (byteComparison != 0) {
+                        return byteComparison;
+                    }
+                }
+                // OK both arrays are the same length and every byte is identical so they are equal
+                return 0;
+            }
+        }
+    }
+
+    private static int unsignedByteToInt(final byte b) {
+        return b < 0 ? (b)+256 : ((int)b);
+    }
+}

--- a/utils/src/main/java/org/opennms/integration/api/utils/IPLike.java
+++ b/utils/src/main/java/org/opennms/integration/api/utils/IPLike.java
@@ -1,0 +1,281 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2008-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.utils;
+
+import java.net.InetAddress;
+
+/**
+ * <p>IPLike class.</p>
+ *
+ * @author ranger
+ * @version $Id: $
+ */
+public abstract class IPLike {
+    private IPLike() {}
+
+    private enum AddressType {
+        IPv4,
+        IPv6,
+    }
+
+    private static class IPv6Address {
+        public final String[] fields;
+        public final String scope;
+
+        private IPv6Address(final String[] fields,
+                            final String scope) {
+            this.fields = fields;
+            this.scope = scope;
+        }
+    }
+
+    private interface RangeMatcher {
+        boolean match(final String value, final String range);
+    }
+
+    private static class HexRangeMatcher implements RangeMatcher {
+        @Override
+        public boolean match(final String value, final String range) {
+            return matchRangeHex(value, range);
+        }
+    }
+
+    private static class DecimalRangeMatcher implements RangeMatcher {
+        @Override
+        public boolean match(final String value, final String range) {
+            return matchRange(value, range);
+        }
+    }
+
+    public static boolean matches(final InetAddress address, final String pattern) {
+        return matches(InetAddressUtils.str(address), pattern);
+    }
+
+    private static AddressType classifyAddress(final String address) {
+        if (address.indexOf(':') != -1) {
+            return AddressType.IPv6;
+        }
+
+        if (address.indexOf('.') != -1) {
+            return AddressType.IPv4;
+        }
+        throw new IllegalArgumentException("Cannot determine whether address is a IPv4 or IPv6 address");
+    }
+
+    private static String[] parseIPv4Address(final String address) {
+        // Split address in fields
+        return address.split("\\.", 0);
+    }
+
+    private static IPv6Address parseIPv6Address(final String address) {
+        // Split of scope identifier
+        final String[] addressAndScope = address.split("%", 2);
+
+        // Split address in fields
+        final String[] fields = addressAndScope[0].split("\\:", 0);
+
+        final String scope = addressAndScope.length == 2
+                             ? addressAndScope[1]
+                             : null;
+
+        return new IPv6Address(fields, scope);
+    }
+
+    /**
+     * <p>matches</p>
+     *
+     * @param address a {@link java.lang.String} object.
+     * @param pattern a {@link java.lang.String} object.
+     * @return a boolean.
+     */
+    public static boolean matches(String address, String pattern) {
+        final AddressType addressType = classifyAddress(address);
+        final AddressType patternType = classifyAddress(pattern);
+
+        if (addressType != patternType) {
+            // Different address types will never match
+            return false;
+        }
+
+        final String[] addressFields;
+        final String[] patternFields;
+        final int expectedFieldCount;
+        final RangeMatcher matcher;
+        switch (addressType) {
+            case IPv4: {
+                addressFields = parseIPv4Address(address);
+                patternFields = parseIPv4Address(pattern);
+                expectedFieldCount = 4;
+                matcher = new DecimalRangeMatcher();
+                break;
+            }
+
+            case IPv6: {
+                final IPv6Address parsedAddress = parseIPv6Address(address);
+                final IPv6Address parsedPattern = parseIPv6Address(pattern);
+
+                if (parsedPattern.scope != null) {
+                    if (parsedAddress.scope == null) {
+                        // Fail if scope is expected but does not exists
+                        return false;
+                    } else {
+                        // Assume that scope identifiers are always decimal
+                        if (!matchNumericListOrRange(parsedAddress.scope, parsedPattern.scope, new DecimalRangeMatcher())) {
+                            return false;
+                        }
+                    }
+                }
+
+                addressFields = parsedAddress.fields;
+                patternFields = parsedPattern.fields;
+                expectedFieldCount = 8;
+                matcher = new HexRangeMatcher();
+                break;
+            }
+
+            default: throw new IllegalStateException();
+        }
+
+        if (addressFields.length != expectedFieldCount) {
+            throw new IllegalArgumentException("Malformatted IP address: " + address);
+        }
+
+        if (patternFields.length != expectedFieldCount) {
+            throw new IllegalArgumentException("Malformatted IPLIKE match expression: " + pattern);
+        }
+
+        for (int i = 0; i < expectedFieldCount; i++) {
+            if (!matchNumericListOrRange(addressFields[i], patternFields[i], matcher)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static boolean matchNumericListOrRange(final String value, final String patterns) {
+        return matchNumericListOrRange(value, patterns, new DecimalRangeMatcher());
+    }
+
+    /**
+     * Use this method to match ranges, lists, and specific number strings
+     * such as:
+     * "200-300" or "200,300,501-700"
+     * "*" matches any
+     * This method is commonly used for matching IP octets or ports
+     *
+     * @param value a {@link java.lang.String} object.
+     * @param patterns a {@link java.lang.String} object.
+     * @return a boolean.
+     */
+    public static boolean matchNumericListOrRange(final String value, final String patterns, final RangeMatcher matcher) {
+        final String[] patternList = patterns.split(",", 0);
+        for (final String element : patternList) {
+            if (matcher.match(value, element)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Helper method in support of matchNumericListOrRange
+     *
+     * @param value a {@link java.lang.String} object.
+     * @param pattern a {@link java.lang.String} object.
+     * @return a boolean.
+     */
+    public static boolean matchRange(final String value, final String pattern) {
+        final int dashCount = countChar('-', pattern);
+
+        if ("*".equals(pattern)) {
+            return true;
+        } else if (dashCount == 0) {
+            return Long.parseLong(pattern, 10) ==  Long.parseLong(value, 10);
+        } else if (dashCount > 1) {
+            return false;
+        } else if (dashCount == 1) {
+            final String[] ar = pattern.split("-");
+            final long rangeBegin = Long.parseLong(ar[0]);
+            final long rangeEnd = Long.parseLong(ar[1]);
+            final long ip = Long.parseLong(value);
+            return (ip >= rangeBegin && ip <= rangeEnd);
+        }
+        return false;
+    }
+
+    /**
+     * Helper method in support of matchNumericListOrRange
+     *
+     * @param value a {@link java.lang.String} object.
+     * @param pattern a {@link java.lang.String} object.
+     * @return a boolean.
+     */
+    public static boolean matchRangeHex(final String value, final String pattern) {
+        final int dashCount = countChar('-', pattern);
+
+        if ("*".equals(pattern)) {
+            return true;
+        } else if (dashCount == 0) {
+            // Convert values to hex integers and compare
+            return Long.parseLong(pattern, 16) ==  Long.parseLong(value, 16);
+        } else if (dashCount > 1) {
+            return false;
+        } else if (dashCount == 1) {
+            final String[] ar = pattern.split("-");
+            final long rangeBegin = Long.parseLong(ar[0], 16);
+            final long rangeEnd = Long.parseLong(ar[1], 16);
+            final long ip = Long.parseLong(value, 16);
+            return (ip >= rangeBegin && ip <= rangeEnd);
+        }
+        return false;
+    }
+
+    /**
+     * <p>countChar</p>
+     *
+     * @param charIn a char.
+     * @param stingIn a {@link java.lang.String} object.
+     * @return a int.
+     */
+    public static int countChar(final char charIn, final String stingIn) {
+
+        int charCount = 0;
+        int charIndex = 0;
+        for (int i=0; i<stingIn.length(); i++) {
+            charIndex = stingIn.indexOf(charIn, i);
+            if (charIndex != -1) {
+                charCount++;
+                i = charIndex +1;
+            }
+        }
+        return charCount;
+    }
+
+}

--- a/utils/src/main/java/org/opennms/integration/api/utils/InetAddressUtils.java
+++ b/utils/src/main/java/org/opennms/integration/api/utils/InetAddressUtils.java
@@ -1,0 +1,761 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2007-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.utils;
+
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.management.remote.JMXServiceURL;
+
+import org.opennms.integration.api.v1.model.immutables.ImmutableIPAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>Abstract InetAddressUtils class.</p>
+ *
+ * @author <a href="mailto:brozow@opennms.org">Mathew Brozowski</a>
+ * @version $Id: $
+ */
+public abstract class InetAddressUtils {
+	private static final Logger LOG = LoggerFactory.getLogger(InetAddressUtils.class);
+
+	private static final Comparator<InetAddress> IFACE_COMPARATOR = (final var iface1, final var iface2) -> {
+	    if (iface1 == null) {
+	        if (iface2 == null) {
+	            return 0;
+	        }
+	        return 1;
+	    } else {
+	        if (iface2 == null) {
+	            return -1;
+	        }
+	        return iface1.getClass().getName().compareTo(iface2.getClass().getName());
+	    }
+	};
+
+    /**
+     * Always print at least one digit after the decimal point,
+     * and at most three digits after the decimal point.
+     */
+    protected static final DecimalFormat NO_DIGITS_AFTER_DECIMAL = new DecimalFormat("0.0##");
+    /**
+     * Print no digits after the decimal point (heh, nor a decimal point).
+     */
+    protected static final DecimalFormat ONE_DIGIT_AFTER_DECIMAL = new DecimalFormat("0");
+
+    public static final String INVALID_BRIDGE_ADDRESS = "000000000000";
+    public static final String INVALID_STP_BRIDGE_ID  = "0000000000000000";
+    public static final String INVALID_STP_BRIDGE_DESIGNATED_PORT = "0000";
+
+    private static final ByteArrayComparator s_BYTE_ARRAY_COMPARATOR = new ByteArrayComparator();
+    public static final InetAddress UNPINGABLE_ADDRESS;
+    public static final InetAddress UNPINGABLE_ADDRESS_IPV6;
+    public static final InetAddress ZEROS = addr("0.0.0.0");
+    public static final InetAddress TWO_FIFTY_FIVES = addr("255.255.255.255");
+    public static final InetAddress ONE_TWENTY_SEVEN = addr("127.0.0.1");
+
+    static {
+        try {
+            // This address (192.0.2.123) is within a range of test IPs that
+            // that is guaranteed to be non-routed.
+            //
+            UNPINGABLE_ADDRESS = InetAddress.getByAddress(new byte[] {(byte)192, (byte)0, (byte)2, (byte)123});
+        } catch (final UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+
+        try {
+            // This address is within a subnet of "Unique Unicast" IPv6 addresses
+            // that are defined by RFC4193. This is the IPv6 equivalent of the
+            // 192.168.0.0/16 subnet and because the IPv6 address space is so large,
+            // you can just randomly generate the first portion of the address. :)
+            // I used an online address generator to get this particular address.
+            //
+            // http://www.rfc-editor.org/rfc/rfc4193.txt
+            //
+            UNPINGABLE_ADDRESS_IPV6 = InetAddress.getByName("fd25:28a0:ba2f:6b78:0000:0000:0000:0001");
+        } catch (final UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private InetAddressUtils() {}
+
+    public enum AddressType {
+        IPv4,
+        IPv6
+    }
+
+    public static InetAddress getLocalHostAddress() {
+        try {
+            return InetAddress.getLocalHost();
+        } catch (final UnknownHostException e) {
+            LOG.warn("getLocalHostAddress: Could not lookup the host address for the local host machine, address set to '127.0.0.1'.", e);
+            return addr("127.0.0.1");
+        }
+    }
+
+    public static String getLocalHostAddressAsString() {
+        final String localhost = str(getLocalHostAddress());
+        return localhost == null? "127.0.0.1" : localhost;
+    }
+
+    public static Optional<InetAddress> getLocalLoopbackAddress() {
+        try {
+            final List<InetAddress> loopbackAddresses = new ArrayList<>();
+            final Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces();
+            while (ifaces.hasMoreElements()) {
+                final NetworkInterface iface = ifaces.nextElement();
+                if (iface.isLoopback() && iface.isUp() && !iface.isVirtual()) {
+                    final Enumeration<InetAddress> addrs = iface.getInetAddresses();
+                    while (addrs.hasMoreElements()) {
+                        final InetAddress addr = addrs.nextElement();
+                        if (!addr.isMulticastAddress() && (addr.isLinkLocalAddress() || addr.isLoopbackAddress() || addr.isAnyLocalAddress())) {
+                            loopbackAddresses.add(addr);
+                        }
+                    }
+                }
+            }
+            if (!loopbackAddresses.isEmpty()) {
+                // prefer IPv4 loopback addresses to IPv6
+                loopbackAddresses.sort(IFACE_COMPARATOR);
+                return Optional.of(loopbackAddresses.get(0));
+            }
+        } catch (final Exception e) {
+            LOG.warn("getLocalLoopbackAddress: an exception occurred while attempting to determine the local loopback address.",e);
+        }
+        return Optional.empty();
+    }
+
+    public static String getLocalHostName() {
+        final InetAddress localHostAddress = getLocalHostAddress();
+        if (localHostAddress == null) {
+            LOG.warn("getLocalHostName: Could not lookup the host name for the local host machine, name set to 'localhost'.");
+            return "localhost";
+        }
+        return localHostAddress.getHostName();
+    }
+
+    public static String incr(final String address) throws UnknownHostException {
+        return InetAddressUtils.toIpAddrString(incr(InetAddressUtils.toIpAddrBytes(address)));
+    }
+
+    public static byte[] incr(final byte[] address) throws UnknownHostException {
+        final BigInteger addr = new BigInteger(1, address).add(BigInteger.ONE);
+        return convertBigIntegerIntoInetAddress(addr).getAddress();
+    }
+
+    public static String decr(final String address) throws UnknownHostException {
+        return InetAddressUtils.toIpAddrString(decr(InetAddressUtils.toIpAddrBytes(address)));
+    }
+
+    public static byte[] decr(final byte[] address) throws UnknownHostException {
+        final BigInteger addr = new BigInteger(1, address).subtract(BigInteger.ONE);
+        return convertBigIntegerIntoInetAddress(addr).getAddress();
+    }
+
+    public static InetAddress getInetAddress(final int[] octets, final int offset, final int length) {
+        final byte[] addressBytes = new byte[length];
+        for (int i = 0; i < addressBytes.length; i++) {
+            addressBytes[i] = (byte) octets[i + offset];
+        }
+        return getInetAddress(addressBytes);
+    }
+
+    public static InetAddress getInetAddress(final byte[] ipAddrOctets) {
+        return new ImmutableIPAddress(ipAddrOctets).toInetAddress();
+    }
+
+    /**
+     * <p>getInetAddress</p>
+     *
+     * @param dottedNotation a {@link java.lang.String} object.
+     * @return a {@link java.net.InetAddress} object.
+     */
+    public static InetAddress getInetAddress(final String dottedNotation) {
+        return new ImmutableIPAddress(dottedNotation).toInetAddress();
+    }
+
+    /**
+     * <p>toIpAddrBytes</p>
+     *
+     * @param dottedNotation a {@link java.lang.String} object.
+     * @return an array of byte.
+     */
+    public static byte[] toIpAddrBytes(final String dottedNotation) {
+        return new ImmutableIPAddress(dottedNotation).toOctets();
+    }
+
+    /**
+     * <p>toIpAddrString</p>
+     *
+     * @param addr IP address
+     * @return a {@link java.lang.String} object.
+     */
+    public static String toIpAddrString(final InetAddress addr) {
+        return new ImmutableIPAddress(addr).toDbString();
+    }
+
+    /**
+     * <p>toIpAddrString</p>
+     *
+     * @param addr an array of byte.
+     * @return a {@link java.lang.String} object.
+     */
+    public static String toIpAddrString(final byte[] addr) {
+        return new ImmutableIPAddress(addr).toDbString();
+    }
+
+    /**
+     * Method that wraps IPv6 addresses in square brackets so that they are parsed
+     * correctly by the {@link JMXServiceURL} class.
+     */
+    public static String toUrlIpAddress(InetAddress addr) {
+        if (addr instanceof Inet6Address) {
+            return String.format("[%s]", str(addr));
+        } else {
+            return str(addr);
+        }
+    }
+
+    /**
+     * Given a list of IP addresses, return the lowest as determined by the
+     * numeric representation and not the alphanumeric string.
+     *
+     * @param addresses a {@link java.util.List} object.
+     * @return a {@link java.net.InetAddress} object.
+     */
+    public static InetAddress getLowestInetAddress(final List<InetAddress> addresses) {
+        if (addresses == null) {
+            throw new IllegalArgumentException("Cannot take null parameters.");
+        }
+
+        InetAddress lowest = null;
+        // Start with the highest conceivable IP address value
+        final byte[] originalBytes = toIpAddrBytes("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+        byte[] lowestBytes = originalBytes;
+        for (final InetAddress temp : addresses) {
+            byte[] tempBytes = temp.getAddress();
+
+            if (s_BYTE_ARRAY_COMPARATOR.compare(tempBytes, lowestBytes) < 0) {
+                lowestBytes = tempBytes;
+                lowest = temp;
+            }
+        }
+
+        return s_BYTE_ARRAY_COMPARATOR.compare(originalBytes, lowestBytes) == 0 ? null : lowest;
+    }
+
+    public static BigInteger difference(final String addr1, final String addr2) {
+        return difference(getInetAddress(addr1), getInetAddress(addr2));
+    }
+
+    public static BigInteger difference(final InetAddress addr1, final InetAddress addr2) {
+        return new BigInteger(1, addr1.getAddress()).subtract(new BigInteger(1, addr2.getAddress()));
+    }
+
+    public static boolean isInetAddressInRange(final byte[] laddr, final String beginString, final String endString) {
+        final byte[] begin = InetAddressUtils.toIpAddrBytes(beginString);
+        final byte[] end = InetAddressUtils.toIpAddrBytes(endString);
+        return isInetAddressInRange(laddr, begin, end);
+    }
+
+    public static boolean isInetAddressInRange(final String addrString, final String beginString, final String endString) {
+        final byte[] addr = InetAddressUtils.toIpAddrBytes(addrString);
+        final byte[] begin = InetAddressUtils.toIpAddrBytes(beginString);
+        if (s_BYTE_ARRAY_COMPARATOR.compare(addr, begin) > 0) {
+            final byte[] end = InetAddressUtils.toIpAddrBytes(endString);
+            return (s_BYTE_ARRAY_COMPARATOR.compare(addr, end) <= 0);
+        }
+        return s_BYTE_ARRAY_COMPARATOR.compare(addr, begin) == 0;
+    }
+
+    public static boolean areSameInetAddress(final byte[] leftInetAddr, final byte[] rightInetAddr){
+        return s_BYTE_ARRAY_COMPARATOR.compare(leftInetAddr, rightInetAddr) == 0;
+    }
+
+    public static boolean inSameScope(final InetAddress addr1, final InetAddress addr2) {
+        if (addr1 instanceof Inet4Address) {
+            return (addr2 instanceof Inet4Address);
+        } else {
+            if (addr2 instanceof Inet4Address) {
+                return false;
+            } else {
+                // Compare the IPv6 scope IDs
+                return Integer.compare(((Inet6Address)addr1).getScopeId(), ((Inet6Address)addr2).getScopeId()) == 0;
+            }
+        }
+    }
+
+    public static InetAddress getIpv4Network(InetAddress ipaddress, InetAddress netmask) {
+        final byte[] ipAddress = ipaddress.getAddress();
+        final byte[] netMask = netmask.getAddress();
+        final byte[] netWork = new byte[4];
+
+        for (int i=0;i< 4; i++) {
+            netWork[i] = (byte) (ipAddress[i] & netMask[i]);
+
+        }
+        return InetAddressUtils.getInetAddress(netWork);
+    }
+
+    public static InetAddress getIpv6Network(InetAddress ipaddress, InetAddress netmask) {
+        final byte[] ipAddress = ipaddress.getAddress();
+        final byte[] netMask = netmask.getAddress();
+        final byte[] netWork = new byte[16];
+
+        for (int i=0;i< 16; i++) {
+            netWork[i] = (byte) (ipAddress[i] & netMask[i]);
+
+        }
+        return InetAddressUtils.getInetAddress(netWork);
+    }
+
+    public static InetAddress getNetwork(InetAddress ipaddress, InetAddress netmask) {
+        if (ipaddress instanceof  Inet4Address && netmask instanceof  Inet4Address) {
+            return getIpv4Network(ipaddress,netmask);
+        }
+        if (ipaddress instanceof Inet6Address && netmask instanceof Inet6Address) {
+            return getIpv6Network(ipaddress,netmask);
+        }
+        throw new UnsupportedOperationException("ip and mask mismacht");
+    }
+
+    public static boolean inSameIpv4Network(final InetAddress addr1, final InetAddress addr2, final InetAddress mask) {
+        final byte[] ipAddress1 = addr1.getAddress();
+        final byte[] ipAddress2 = addr2.getAddress();
+        final byte[] netMask = mask.getAddress();
+
+        for (int i=0;i< 4; i++) {
+            if ((ipAddress1[i] & netMask[i]) != (ipAddress2[i] & netMask[i]))
+                return false;
+
+        }
+        return true;
+    }
+
+    public static boolean inSameIpv6Network(final InetAddress addr1, final InetAddress addr2, final InetAddress mask) {
+        final byte[] ipAddress1 = addr1.getAddress();
+        final byte[] ipAddress2 = addr2.getAddress();
+        final byte[] netMask = mask.getAddress();
+
+        for (int i=0;i< 16; i++) {
+            if ((ipAddress1[i] & netMask[i]) != (ipAddress2[i] & netMask[i]))
+                return false;
+
+        }
+        return true;
+    }
+
+    public static boolean isPointToPointMask(InetAddress mask) {
+        if (mask.equals(addr("255.255.255.252"))) {
+            return true;
+        }
+        return mask.equals(addr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffd"));
+    }
+
+    public static boolean isLoopbackMask(InetAddress mask) {
+        if (mask.equals(addr("255.255.255.255"))) {
+            return true;
+        }
+        return mask.equals(addr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+    }
+
+    public static boolean inSameNetwork(final InetAddress addr1, final InetAddress addr2, final InetAddress mask) {
+        if (addr1 instanceof Inet4Address && addr2 instanceof Inet4Address && mask instanceof Inet4Address)
+            return inSameIpv4Network(addr1,addr2,mask);
+        if (addr1 instanceof Inet6Address && addr2 instanceof Inet6Address && mask instanceof Inet6Address)
+            return inSameIpv6Network(addr1,addr2,mask);
+        return false;
+    }
+
+    public static boolean isInetAddressInRange(final byte[] addr, final byte[] begin, final byte[] end) {
+        if (s_BYTE_ARRAY_COMPARATOR.compare(addr, begin) > 0) {
+            return (s_BYTE_ARRAY_COMPARATOR.compare(addr, end) <= 0);
+        } else {
+            return s_BYTE_ARRAY_COMPARATOR.compare(addr, begin) == 0;
+        }
+    }
+
+    public static boolean isInetAddressInRange(final String ipAddr, final byte[] begin, final byte[] end) {
+        return isInetAddressInRange(InetAddressUtils.toIpAddrBytes(ipAddr), begin, end);
+    }
+
+    public static int convertInetAddressMaskToCidr(InetAddress mask) {
+        byte[] addr = mask.getAddress();
+        boolean foundZero = false;
+        int cidr = 0;
+        for (int i=0; i< addr.length; i++) {
+            Byte value= addr[i];
+            int k=0;
+            if (foundZero && value.intValue() != 0) {
+                throw new IllegalArgumentException("Error in mask: " + str(mask));
+            }
+            if (value.intValue() < 0) {
+                k = 256 + value.intValue();
+            }
+            switch (k) {
+                case 255:
+                    cidr=cidr+8;
+                    break;
+                case 254:
+                    cidr=cidr+7;
+                    foundZero=true;
+                    break;
+                case 252:
+                    cidr=cidr+6;
+                    foundZero=true;
+                    break;
+                case 248:
+                    cidr=cidr+5;
+                    foundZero=true;
+                    break;
+                case 240:
+                    cidr=cidr+4;
+                    foundZero=true;
+                    break;
+                case 224:
+                    cidr=cidr+3;
+                    foundZero=true;
+                    break;
+                case 192:
+                    cidr=cidr+2;
+                    foundZero=true;
+                    break;
+                case 128:
+                    cidr=cidr+1;
+                    foundZero=true;
+                    break;
+                case 0:
+                    foundZero=true;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Error in mask: " + str(mask));
+            }
+        }
+        return cidr;
+    }
+
+    public static InetAddress convertCidrToInetAddressV4(int cidr) {
+        if (cidr < 0 || cidr > 32) {
+            throw new IllegalArgumentException("Illegal IPv4 CIDR mask length: " + cidr);
+        }
+        final StringBuilder binaryString = new StringBuilder();
+        int i = 0;
+        for (; i < cidr; i++) {
+            binaryString.append('1');
+        }
+        for (; i < 32; i++) {
+            binaryString.append('0');
+        }
+        try {
+            return convertBigIntegerIntoInetAddress(new BigInteger(binaryString.toString(), 2));
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Could not convert CIDR mask to InetAddress: " + e.getMessage());
+        }
+    }
+
+    public static InetAddress convertCidrToInetAddressV6(int cidr) {
+        if (cidr < 0 || cidr > 128) {
+            throw new IllegalArgumentException("Illegal IPv6 CIDR mask length: " + cidr);
+        }
+        final StringBuilder binaryString = new StringBuilder();
+        int i = 0;
+        for (; i < cidr; i++) {
+            binaryString.append('1');
+        }
+        for (; i < 128; i++) {
+            binaryString.append('0');
+        }
+        try {
+            return convertBigIntegerIntoInetAddress(new BigInteger(binaryString.toString(), 2));
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Could not convert CIDR mask to InetAddress: " + e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("java:S3776")
+    public static InetAddress convertBigIntegerIntoInetAddress(final BigInteger i) throws UnknownHostException {
+        if (i.compareTo(BigInteger.ZERO) < 0) {
+            throw new IllegalArgumentException("BigInteger is negative, cannot convert into an IP address: " + i.toString());
+        } else {
+            // Note: This function will return the two's complement byte array so there will always
+            // be a bit of value '0' (indicating positive sign) at the first position of the array
+            // and it will be padded to the byte boundry. For example:
+            //
+            // 255.255.255.255 => 00 FF FF FF FF (5 bytes)
+            // 127.0.0.1 => 0F 00 00 01 (4 bytes)
+            //
+            final byte[] bytes = i.toByteArray();
+
+            if (bytes.length == 0) {
+                return InetAddress.getByAddress(new byte[] {0, 0, 0, 0});
+            } else if (bytes.length <= 4) {
+                // This case covers an IPv4 address with the most significant bit of zero (the MSB
+                // will be used as the two's complement sign bit)
+                final byte[] addressBytes = new byte[4];
+                int k = 3;
+                for (int j = bytes.length - 1; j >= 0; j--, k--) {
+                    addressBytes[k] = bytes[j];
+                }
+                return InetAddress.getByAddress(addressBytes);
+            } else if (bytes.length <= 5 && bytes[0] == 0) {
+                // This case covers an IPv4 address (4 bytes + two's complement sign bit of zero)
+                final byte[] addressBytes = new byte[4];
+                int k = 3;
+                for (int j = bytes.length - 1; j >= 1; j--, k--) {
+                    addressBytes[k] = bytes[j];
+                }
+                return InetAddress.getByAddress(addressBytes);
+            } else if (bytes.length <= 16) {
+                // This case covers an IPv6 address with the most significant bit of zero (the MSB
+                // will be used as the two's complement sign bit)
+                final byte[] addressBytes = new byte[16];
+                int k = 15;
+                for (int j = bytes.length - 1; j >= 0; j--, k--) {
+                    addressBytes[k] = bytes[j];
+                }
+                return InetAddress.getByAddress(addressBytes);
+            } else if (bytes.length <= 17 && bytes[0] == 0) {
+                // This case covers an IPv6 address (16 bytes + two's complement sign bit of zero)
+                final byte[] addressBytes = new byte[16];
+                int k = 15;
+                for (int j = bytes.length - 1; j >= 1; j--, k--) {
+                    addressBytes[k] = bytes[j];
+                }
+                return InetAddress.getByAddress(addressBytes);
+            } else {
+                throw new IllegalArgumentException("BigInteger is too large to convert into an IP address: " + i.toString());
+            }
+        }
+    }
+
+    public static InetAddress addr(final String ipAddrString) {
+        return ipAddrString == null ? null : getInetAddress(ipAddrString.trim());
+    }
+
+    /**
+     * This function is used to ensure that an IP address string is in fully-qualified
+     * format without any "::" segments for an IPv6 address.
+     */
+    public static String normalize(final String ipAddrString) {
+        return ipAddrString == null? null : toIpAddrString(addr(ipAddrString.trim()));
+    }
+
+    public static String str(final InetAddress addr) {
+        return addr == null ? null : toIpAddrString(addr);
+    }
+
+    public static BigInteger toInteger(final InetAddress ipAddress) {
+        return new BigInteger(1, ipAddress.getAddress());
+    }
+
+    public static String toOid(final InetAddress addr) {
+        if (addr == null) return null;
+
+        if (addr instanceof Inet4Address) {
+            return str(addr);
+        } else if (addr instanceof Inet6Address) {
+            // This is horribly inefficient, I'm sure, but good enough for now.
+            final byte[] buf = addr.getAddress();
+            final StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < buf.length; i++) {
+                sb.append(buf[i] & 0xff);
+                if (i != (buf.length - 1)) {
+                    sb.append(".");
+                }
+            }
+            return sb.toString();
+        } else {
+            LOG.debug("don't know how to handle {}", addr);
+            return null;
+        }
+    }
+
+    public static byte[] macAddressStringToBytes(String macAddress) {
+        if (macAddress == null) {
+            throw new IllegalArgumentException("Cannot decode null MAC address");
+        }
+
+        byte[] contents = new byte[6];
+        String[] digits = macAddress.split(":");
+        if (digits.length != 6) {
+            // If the MAC address is 12 hex digits long
+            if (macAddress.length() == 12) {
+                digits = new String[] {
+                        macAddress.substring(0, 2),
+                        macAddress.substring(2, 4),
+                        macAddress.substring(4, 6),
+                        macAddress.substring(6, 8),
+                        macAddress.substring(8, 10),
+                        macAddress.substring(10)
+                };
+            } else {
+                throw new IllegalArgumentException("Cannot decode MAC address: '" + macAddress + "'");
+            }
+        }
+        // Decode each MAC address digit into a hexadecimal byte value
+        for (int i = 0; i < 6; i++) {
+            // Prefix the value with "0x" so that Integer.decode() knows which base to use
+            contents[i] = Integer.decode("0x" + digits[i]).byteValue();
+        }
+        return contents;
+    }
+
+    public static String macAddressBytesToString(byte[] macAddress) {
+        if (macAddress.length != 6) {
+            throw new IllegalArgumentException("Cannot decode MAC address: " + Arrays.toString(macAddress));
+        }
+
+        return String.format(
+                             //"%02X:%02X:%02X:%02X:%02X:%02X",
+                             "%02x%02x%02x%02x%02x%02x",
+                             macAddress[0],
+                             macAddress[1],
+                             macAddress[2],
+                             macAddress[3],
+                             macAddress[4],
+                             macAddress[5]
+                );
+    }
+
+    public static String normalizeMacAddress(String macAddress) {
+        return macAddressBytesToString(macAddressStringToBytes(macAddress));
+    }
+
+    public static boolean isValidStpDesignatedPort(String bridgeDesignatedPort) {
+        if (bridgeDesignatedPort == null || bridgeDesignatedPort.equals(INVALID_STP_BRIDGE_DESIGNATED_PORT))
+                return false;
+        Pattern pattern = Pattern.compile("([0-9a-f]{4})");
+        Matcher matcher = pattern.matcher(bridgeDesignatedPort);
+        return matcher.matches();
+    }
+
+    public static int getBridgeDesignatedPortNumber(String stpPortDesignatedPort) {
+        return 8191 & Integer.parseInt(stpPortDesignatedPort,
+                16);
+    }
+
+    public static boolean isValidBridgeAddress(String bridgeAddress) {
+            if (bridgeAddress == null || bridgeAddress.equals(INVALID_BRIDGE_ADDRESS))
+                    return false;
+            Pattern pattern = Pattern.compile("([0-9a-f]{12})");
+            Matcher matcher = pattern.matcher(bridgeAddress);
+            return matcher.matches();
+    }
+
+    public static boolean isValidStpBridgeId(String bridgeId) {
+            if (bridgeId == null || bridgeId.equals(INVALID_STP_BRIDGE_ID))
+                    return false;
+            Pattern pattern = Pattern.compile("([0-9a-f]{16})");
+            Matcher matcher = pattern.matcher(bridgeId);
+            return matcher.matches();
+    }
+
+    public static String getBridgeAddressFromStpBridgeId(String bridgeId) {
+        return bridgeId.substring(4, 16);
+    }
+
+    public static InetAddress getIpAddressByHexString(String ipaddrhexstrng) {
+
+        long ipAddr = Long.parseLong(ipaddrhexstrng, 16);
+        byte[] bytes = new byte[4];
+        bytes[3] = (byte) (ipAddr & 0xff);
+        bytes[2] = (byte) ((ipAddr >> 8) & 0xff);
+        bytes[1] = (byte) ((ipAddr >> 16) & 0xff);
+        bytes[0] = (byte) ((ipAddr >> 24) & 0xff);
+
+        return InetAddressUtils.getInetAddress(bytes);
+   }
+
+    /**
+     * Method used to convert an integer bits-per-second value to a more
+     * readable vale using commonly recognized abbreviation for network
+     * interface speeds. Feel free to expand it as necessary to accommodate
+     * different values.
+     *
+     * @param ifSpeed
+     *            The bits-per-second value to be converted into a string
+     *            description
+     * @return A string representation of the speed (&quot;100 Mbps&quot; for
+     *         example)
+     */
+    public static String getHumanReadableIfSpeed(long ifSpeed) {
+        DecimalFormat formatter;
+        double displaySpeed;
+        String units;
+
+        if (ifSpeed >= 1000000000L) {
+            if ((ifSpeed % 1000000000L) == 0) {
+                formatter = NO_DIGITS_AFTER_DECIMAL;
+            } else {
+                formatter = ONE_DIGIT_AFTER_DECIMAL;
+            }
+            displaySpeed = ifSpeed / 1000000000.0;
+            units = "Gbps";
+        } else if (ifSpeed >= 1000000L) {
+            if ((ifSpeed % 1000000L) == 0) {
+                formatter = NO_DIGITS_AFTER_DECIMAL;
+            } else {
+                formatter = ONE_DIGIT_AFTER_DECIMAL;
+            }
+            displaySpeed = ifSpeed / 1000000.0;
+            units = "Mbps";
+        } else if (ifSpeed >= 1000L) {
+            if ((ifSpeed % 1000L) == 0) {
+                formatter = NO_DIGITS_AFTER_DECIMAL;
+            } else {
+                formatter = ONE_DIGIT_AFTER_DECIMAL;
+            }
+            displaySpeed = ifSpeed / 1000.0;
+            units = "kbps";
+        } else {
+            formatter = NO_DIGITS_AFTER_DECIMAL;
+            displaySpeed = ifSpeed;
+            units = "bps";
+        }
+
+        return formatter.format(displaySpeed) + " " + units;
+    }
+
+}

--- a/utils/src/test/java/org/opennms/integration/api/utils/InetAddressUtilsTest.java
+++ b/utils/src/test/java/org/opennms/integration/api/utils/InetAddressUtilsTest.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.opennms.integration.api.utils.InetAddressUtils.str;
+
+import java.math.BigInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InetAddressUtilsTest {
+
+    @Test
+    public void testMacAddressFunctions() throws Exception {
+        byte[] expected = new byte[] {
+            (byte)0xff,
+            (byte)0x80,
+            (byte)0x0f,
+            (byte)0xf0,
+            (byte)0x01,
+            (byte)0x00
+        };
+        byte[] actual = InetAddressUtils.macAddressStringToBytes("ff:80:f:f0:01:00");
+        Assert.assertArrayEquals(expected, actual);
+        //assertEquals("FF:80:0F:F0:01:00", InetAddressUtils.macAddressBytesToString(actual));
+        assertEquals("ff800ff00100", InetAddressUtils.macAddressBytesToString(actual));
+
+        actual = InetAddressUtils.macAddressStringToBytes("ff:80:f:f0:01:0");
+        Assert.assertArrayEquals(expected, actual);
+        assertEquals("ff800ff00100", InetAddressUtils.macAddressBytesToString(actual));
+
+        actual = InetAddressUtils.macAddressStringToBytes("ff800ff00100");
+        Assert.assertArrayEquals(expected, actual);
+        assertEquals("ff800ff00100", InetAddressUtils.macAddressBytesToString(actual));
+
+        try {
+            InetAddressUtils.macAddressStringToBytes("ff800ff0010");
+            fail("Parsed MAC address value that was too short");
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            InetAddressUtils.macAddressStringToBytes("ff800ff001000");
+            fail("Parsed MAC address value that was too long");
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testNMS4972() throws Exception {
+        String ip1 = "1.1.1.1";
+        String ip2 = "255.255.255.255";
+        Assert.assertFalse(BigInteger.ZERO.compareTo(InetAddressUtils.difference(ip1, ip2)) < 0);
+    }
+
+    @Test
+    public void testCidrFunctions() throws Exception {
+        assertEquals("255.0.0.0", str(InetAddressUtils.convertCidrToInetAddressV4(8)));
+        assertEquals("255.255.0.0", str(InetAddressUtils.convertCidrToInetAddressV4(16)));
+        assertEquals("255.255.255.0", str(InetAddressUtils.convertCidrToInetAddressV4(24)));
+        assertEquals("255.255.255.255", str(InetAddressUtils.convertCidrToInetAddressV4(32)));
+
+        assertEquals("ffff:ffff:ffff:0000:0000:0000:0000:0000", str(InetAddressUtils.convertCidrToInetAddressV6(48)));
+        assertEquals("ffff:ffff:ffff:ffff:0000:0000:0000:0000", str(InetAddressUtils.convertCidrToInetAddressV6(64)));
+        assertEquals("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", str(InetAddressUtils.convertCidrToInetAddressV6(128)));
+    }
+
+    @Test
+    public void testGetNetwork() throws Exception {
+        assertEquals("192.168.1.0", str(InetAddressUtils.getNetwork(InetAddressUtils.addr("192.168.1.3"),InetAddressUtils.addr("255.255.255.0"))));
+        assertEquals("192.168.0.0", str(InetAddressUtils.getNetwork(InetAddressUtils.addr("192.168.1.3"),InetAddressUtils.addr("255.255.0.0"))));
+        assertEquals("192.0.0.0", str(InetAddressUtils.getNetwork(InetAddressUtils.addr("192.168.1.3"),InetAddressUtils.addr("255.0.0.0"))));
+        assertEquals("fd25:28a1:ba2f:0000:0000:0000:0000:0000", str(InetAddressUtils.getNetwork(InetAddressUtils.addr("fd25:28a1:ba2f:6b78:0000:0000:0000:0001"),InetAddressUtils.addr("ffff:ffff:ffff:0:0:0:0:0"))));
+        assertEquals("fd25:28a1:ba2f:6b78:0000:0000:0000:0000", str(InetAddressUtils.getNetwork(InetAddressUtils.addr("fd25:28a1:ba2f:6b78:0000:0000:0000:0001"),InetAddressUtils.addr("ffff:ffff:ffff:ffff:0:0:0:0"))));
+    }
+
+    @Test
+    public void testGetCidr() throws Exception {
+        assertEquals(1, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("128.0.0.0")));
+        assertEquals(2, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("192.0.0.0")));
+        assertEquals(3, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("224.0.0.0")));
+        assertEquals(4, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("240.0.0.0")));
+        assertEquals(5, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("248.0.0.0")));
+        assertEquals(6, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("252.0.0.0")));
+        assertEquals(7, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("254.0.0.0")));
+        assertEquals(8, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.0.0.0")));
+        assertEquals(9, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.128.0.0")));
+        assertEquals(10, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.192.0.0")));
+        assertEquals(11, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.224.0.0")));
+        assertEquals(12, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.240.0.0")));
+        assertEquals(13, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.248.0.0")));
+        assertEquals(14, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.252.0.0")));
+        assertEquals(15, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.254.0.0")));
+        assertEquals(16, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.255.0.0")));
+        assertEquals(24, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.255.255.0")));
+        assertEquals(32, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.255.255.255")));
+        assertEquals(64, InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("ffff:ffff:ffff:ffff:0:0:0:0")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectNotValidMask() {
+        InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.128.255.0"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectNotValidMaskValue() {
+        InetAddressUtils.convertInetAddressMaskToCidr(InetAddressUtils.addr("255.255.251.0"));
+    }
+
+
+}


### PR DESCRIPTION
The only thing PRIS actually needs is the XSDs for requisitions, except that it's trying to use the `IPLike` utility class from `opennms-util` and is thus pulling in a bunch of dependency stuff because of it.

`IPLike` and `InetAddressUtils` are generally useful, and it seems reasonable to stick them in OPA to make them more generally available.

The only significant change from the OpenNMS version is I took `org.opennms.core.network.IPAddress` and turned it into `ImmutableIPAddress` and fixed the few methods that weren't immutable.