### PR TITLE
NMS-15808: add new enlinkd protocols

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2019 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2019 The OpenNMS Group, Inc.
+ * Copyright (C) 2019-2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -30,6 +30,9 @@ package org.opennms.integration.api.v1.model;
 
 /**
  * The set of protocols supported by OpenNMS topology.
+ * 
+ * NOTE: If you modify this file, you <strong>must</strong> also update the <code>opennms-kafka-producer.proto</code> in ALEC,
+ * as well as anything relying on this enum in Enlinkd and Topology in OpenNMS proper.
  */
 public enum TopologyProtocol {
     /**
@@ -38,16 +41,21 @@ public enum TopologyProtocol {
     ALL,
 
     BRIDGE,
-
     CDP,
-
     ISIS,
-
     LLDP,
-
     NODES,
-
     OSPF,
+    USERDEFINED,
 
-    USERDEFINED
+    /**
+     * @since 1.6
+     */
+    OSPFAREA,
+
+    /**
+     * @since 1.6
+     */
+    NETWORKROUTER;
 }
+

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
@@ -32,7 +32,8 @@ package org.opennms.integration.api.v1.model;
  * The set of protocols supported by OpenNMS topology.
  * 
  * NOTE: If you modify this file, you <strong>must</strong> also update the <code>opennms-kafka-producer.proto</code> in ALEC,
- * as well as anything relying on this enum in Enlinkd and Topology in OpenNMS proper.
+ * as well as anything relying on this enum in Enlinkd and Topology in OpenNMS proper
+ * (including the copy of <code>opennms-kafka-producer.proto</code> in features/kafka/producer).
  */
 public enum TopologyProtocol {
     /**

--- a/karaf-features/pom.xml
+++ b/karaf-features/pom.xml
@@ -105,20 +105,24 @@
         <dependency>
             <groupId>org.opennms.integration.api</groupId>
             <artifactId>api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.opennms.integration.api</groupId>
             <artifactId>config</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.opennms.integration.api.sample</groupId>
             <artifactId>sample-project</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.istack</groupId>
             <artifactId>istack-commons-runtime</artifactId>
             <version>4.2.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Framework distribution -->


### PR DESCRIPTION
Horizon 32 added new protocols, they need to be in OPA so that ALEC can reference them.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-15808
