### PR TITLE
Update circleCI config, use latest docker images and update the image used for merge step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   build-executor:
     docker:
-      - image: circleci/openjdk:11.0.7-jdk-buster
+      - image: cimg/openjdk:11.0.7
 
 orbs:
   branch-management: opennms/branch-management@2.3.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ executors:
   build-executor:
     docker:
       - image: cimg/openjdk:11.0.7
+  next-build-executor:
+    docker:
+      - image: cimg/openjdk:17.0.11
 
 orbs:
   branch-management: opennms/branch-management@2.3.0
@@ -82,7 +85,7 @@ jobs:
             - project
 
   merge:
-    executor: build-executor
+    executor: next-build-executor
     environment:
       MAVEN_OPTS: -Xmx1024m
 


### PR DESCRIPTION
* replacing `circleci/openjdk` image as it's deprecated ;
* make sure the merge to master is done using jdk 17 image;


### All Contributors

* [x] Have you read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md)?
* [x] Have you (electronically) signed the [OpenNMS Contributor Agreement](https://cla-assistant.io/OpenNMS/opennms)?

