### PR TITLE
chore: Change header from AGPLv3 to Apache 2.0

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/alarms/AlarmLifecycleListener.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/alarms/AlarmLifecycleListener.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/alarms/AlarmPersisterExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/alarms/AlarmPersisterExtension.java
@@ -7,18 +7,18 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/annotations/Consumable.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/annotations/Consumable.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/annotations/Exposable.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/annotations/Exposable.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/annotations/Model.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/annotations/Model.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectionRequest.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectionRequest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectionSet.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectionSet.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectionSetPersistenceService.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectionSetPersistenceService.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectorRequestBuilder.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/CollectorRequestBuilder.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/RrdRepository.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/RrdRepository.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/ServiceCollector.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/ServiceCollector.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/ServiceCollectorClient.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/ServiceCollectorClient.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/ServiceCollectorFactory.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/ServiceCollectorFactory.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/CollectionSetResource.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/CollectionSetResource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/GenericTypeResource.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/GenericTypeResource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/IpInterfaceResource.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/IpInterfaceResource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/NodeResource.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/NodeResource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/NumericAttribute.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/NumericAttribute.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/Resource.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/Resource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/StringAttribute.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/collectors/resource/StringAttribute.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/collector/AddressRange.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/collector/AddressRange.java
@@ -7,18 +7,18 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/collector/Collector.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/collector/Collector.java
@@ -7,18 +7,18 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/collector/CollectorConfigurationExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/collector/CollectorConfigurationExtension.java
@@ -7,18 +7,18 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/collector/Package.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/collector/Package.java
@@ -7,18 +7,18 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/collector/Parameter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/collector/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/collector/Service.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/collector/Service.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/Collect.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/Collect.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/Group.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/Group.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/IpList.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/IpList.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/MibObj.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/MibObj.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/MibObjProperty.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/MibObjProperty.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/Parameter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/ResourceType.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/ResourceType.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/ResourceTypesExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/ResourceTypesExtension.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/SnmpCollectionExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/SnmpCollectionExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/SnmpDataCollection.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/SnmpDataCollection.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/StrategyDefinition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/StrategyDefinition.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/SystemDef.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/SystemDef.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/graphs/GraphPropertiesExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/graphs/GraphPropertiesExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/graphs/PrefabGraph.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/datacollection/graphs/PrefabGraph.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/AlarmData.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/AlarmData.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/AlarmType.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/AlarmType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/AttributeType.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/AttributeType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/CollectionGroup.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/CollectionGroup.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/EventConfExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/EventConfExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/EventDefinition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/EventDefinition.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/LogMessage.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/LogMessage.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/LogMsgDestType.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/LogMsgDestType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/ManagedObject.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/ManagedObject.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/Mask.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/Mask.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/MaskElement.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/MaskElement.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/Parameter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/UpdateField.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/UpdateField.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/events/Varbind.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/events/Varbind.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/AddressRange.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/AddressRange.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/Downtime.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/Downtime.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/Monitor.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/Monitor.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/Package.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/Package.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/Parameter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/PollerConfigurationExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/PollerConfigurationExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/Rrd.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/Rrd.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/poller/Service.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/poller/Service.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/requisition/Requisition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/requisition/Requisition.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionAsset.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionAsset.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionInterface.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionInterface.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionMetaData.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionMetaData.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionMonitoredService.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionMonitoredService.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionNode.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/requisition/RequisitionNode.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/requisition/SnmpPrimaryType.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/requisition/SnmpPrimaryType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/syslog/ParameterAssignment.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/syslog/ParameterAssignment.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/syslog/SyslogMatch.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/syslog/SyslogMatch.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/syslog/SyslogMatchExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/syslog/SyslogMatchExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Basethresholddef.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Basethresholddef.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ExcludeRange.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ExcludeRange.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Expression.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Expression.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Filter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Filter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/FilterOperator.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/FilterOperator.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/GroupDefinition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/GroupDefinition.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/IncludeRange.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/IncludeRange.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/PackageDefinition.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/PackageDefinition.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Parameter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ResourceFilter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ResourceFilter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Service.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Service.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ServiceStatus.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ServiceStatus.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThreshdConfigurationExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThreshdConfigurationExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Threshold.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/Threshold.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdType.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdingConfigExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/config/thresholding/ThresholdingConfigExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/coordination/DomainManager.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/coordination/DomainManager.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/coordination/DomainManagerFactory.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/coordination/DomainManagerFactory.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/coordination/Role.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/coordination/Role.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/coordination/RoleChangeHandler.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/coordination/RoleChangeHandler.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/AlarmDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/AlarmDao.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/AlarmFeedbackDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/AlarmFeedbackDao.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/EdgeDao.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/InterfaceToNodeCache.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/InterfaceToNodeCache.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/NodeDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/NodeDao.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/dao/SnmpInterfaceDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/dao/SnmpInterfaceDao.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectRequest.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectRequest.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectResults.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectResults.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectorClient.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/DetectorClient.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetector.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetector.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/detectors/ServiceDetectorFactory.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/distributed/KeyValueStore.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/distributed/KeyValueStore.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/events/EventForwarder.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/events/EventForwarder.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/events/EventListener.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/events/EventListener.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/events/EventSubscriptionService.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/events/EventSubscriptionService.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/feedback/AlarmFeedbackListener.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/feedback/AlarmFeedbackListener.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/flows/Flow.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/flows/Flow.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/flows/FlowException.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/flows/FlowException.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/flows/FlowRepository.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/flows/FlowRepository.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/Edge.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/Edge.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/Graph.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/Graph.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainer.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainer.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainerCache.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainerCache.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainerInfo.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainerInfo.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainerProvider.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/GraphContainerProvider.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/GraphInfo.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/GraphInfo.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/GraphProvider.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/GraphProvider.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/NodeRef.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/NodeRef.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/Properties.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/Properties.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/Vertex.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/Vertex.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/VertexRef.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/VertexRef.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/configuration/GraphCacheStrategy.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/configuration/GraphCacheStrategy.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/configuration/GraphConfiguration.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/configuration/GraphConfiguration.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/configuration/TopologyConfiguration.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/configuration/TopologyConfiguration.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/status/LegacyStatusProvider.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/status/LegacyStatusProvider.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/status/StatusInfo.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/status/StatusInfo.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/graph/status/StatusProvider.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/graph/status/StatusProvider.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/health/Context.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/health/Context.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/health/HealthCheck.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/health/HealthCheck.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/health/Response.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/health/Response.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/health/Status.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/health/Status.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/Alarm.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/Alarm.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/AlarmFeedback.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/AlarmFeedback.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/DatabaseEvent.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/DatabaseEvent.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/EventParameter.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/EventParameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/Geolocation.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/Geolocation.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/InMemoryEvent.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/InMemoryEvent.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/IpInterface.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/IpInterface.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/MetaData.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/MetaData.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/MonitoredService.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/MonitoredService.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/Node.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/Node.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/NodeAssetRecord.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/NodeAssetRecord.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/NodeCriteria.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/NodeCriteria.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/Severity.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/Severity.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/SnmpInterface.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/SnmpInterface.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyEdge.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyPort.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyPort.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyProtocol.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologyRef.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologyRef.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/model/TopologySegment.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/model/TopologySegment.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/pollers/PollerRequest.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/pollers/PollerRequest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/pollers/PollerRequestBuilder.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/pollers/PollerRequestBuilder.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/pollers/PollerResult.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/pollers/PollerResult.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/pollers/ServicePoller.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/pollers/ServicePoller.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/pollers/ServicePollerClient.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/pollers/ServicePollerClient.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/pollers/ServicePollerFactory.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/pollers/ServicePollerFactory.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/pollers/Status.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/pollers/Status.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/requisition/RequisitionProvider.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/requisition/RequisitionProvider.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/requisition/RequisitionRepository.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/requisition/RequisitionRepository.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/requisition/RequisitionRequest.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/requisition/RequisitionRequest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/runtime/Container.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/runtime/Container.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/runtime/RuntimeInfo.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/runtime/RuntimeInfo.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/runtime/Version.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/runtime/Version.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/scv/Credentials.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/scv/Credentials.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  * OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/scv/SecureCredentialsVault.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/scv/SecureCredentialsVault.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  * OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/ticketing/Ticket.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/ticketing/Ticket.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/ticketing/TicketingPlugin.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/ticketing/TicketingPlugin.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/Aggregation.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/Aggregation.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/DataPoint.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/DataPoint.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/IntrinsicTagNames.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/IntrinsicTagNames.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/Metric.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/Metric.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/Sample.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/Sample.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/StorageException.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/StorageException.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/Tag.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/Tag.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/TagMatcher.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/TagMatcher.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/TimeSeriesFetchRequest.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/TimeSeriesFetchRequest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/TimeSeriesStorage.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/TimeSeriesStorage.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/timeseries/package-info.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/timeseries/package-info.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing &lt;license@opennms.org&gt;

--- a/api/src/main/java/org/opennms/integration/api/v1/topology/IconIds.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/topology/IconIds.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/topology/TopologyEdgeConsumer.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/topology/TopologyEdgeConsumer.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/topology/UserDefinedLink.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/topology/UserDefinedLink.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/topology/UserDefinedLinkDao.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/topology/UserDefinedLinkDao.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/api/src/main/java/org/opennms/integration/api/v1/ui/UIExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/ui/UIExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/immutables/ImmutableNumericAttribute.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/immutables/ImmutableNumericAttribute.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/immutables/ImmutableRrdRepository.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/immutables/ImmutableRrdRepository.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/immutables/ImmutableStringAttribute.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/immutables/ImmutableStringAttribute.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableCollectionSet.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableCollectionSet.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableCollectionSetResource.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableCollectionSetResource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableGenericTypeResource.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableGenericTypeResource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableIpInterfaceResource.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableIpInterfaceResource.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableNodeResource.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/collectors/resource/immutables/ImmutableNodeResource.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/config/datacollection/graphs/immutables/ImmutablePrefabGraph.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/config/datacollection/graphs/immutables/ImmutablePrefabGraph.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisition.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisition.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionAsset.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionAsset.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionInterface.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionMetaData.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionMetaData.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionMonitoredService.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionMonitoredService.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionNode.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/config/requisition/immutables/ImmutableRequisitionNode.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableEdge.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableElement.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableElement.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraph.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraph.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraphContainer.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraphContainer.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraphContainerInfo.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraphContainerInfo.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraphInfo.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableGraphInfo.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableNodeRef.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableNodeRef.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableVertex.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableVertex.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableVertexRef.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/immutables/ImmutableVertexRef.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/graph/status/immutables/StatusInfoImmutable.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/graph/status/immutables/StatusInfoImmutable.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/health/immutables/ImmutableResponse.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/health/immutables/ImmutableResponse.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableAlarm.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableAlarm.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableAlarmFeedback.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableAlarmFeedback.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableDatabaseEvent.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableDatabaseEvent.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableEventParameter.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableEventParameter.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableGeolocation.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableGeolocation.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIPAddress.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIPAddress.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableInMemoryEvent.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableInMemoryEvent.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableIpInterface.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMetaData.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMetaData.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMonitoredService.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableMonitoredService.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNode.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeAssetRecord.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeAssetRecord.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableNodeCriteria.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableSnmpInterface.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableSnmpInterface.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyEdge.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologyPort.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/model/immutables/ImmutableTopologySegment.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/pollers/immutables/ImmutablePollerResult.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/pollers/immutables/ImmutablePollerResult.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/scv/immutables/ImmutableCredentials.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/scv/immutables/ImmutableCredentials.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  * OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/ticketing/immutables/ImmutableTicket.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/ticketing/immutables/ImmutableTicket.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetric.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableSample.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableSample.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTag.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTagMatcher.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTagMatcher.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTimeSeriesFetchRequest.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableTimeSeriesFetchRequest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/MetricValidator.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/timeseries/immutables/MetricValidator.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/topology/immutables/ImmutableUserDefinedLink.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/topology/immutables/ImmutableUserDefinedLink.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/util/ImmutableCollections.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/util/ImmutableCollections.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/main/java/org/opennms/integration/api/v1/util/MutableCollections.java
+++ b/common/src/main/java/org/opennms/integration/api/v1/util/MutableCollections.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/test/java/org/opennms/integration/api/v1/graph/configuration/GraphCacheStrategyTest.java
+++ b/common/src/test/java/org/opennms/integration/api/v1/graph/configuration/GraphCacheStrategyTest.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/test/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetricTest.java
+++ b/common/src/test/java/org/opennms/integration/api/v1/timeseries/immutables/ImmutableMetricTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/test/java/org/opennms/integration/api/v1/util/ImmutableCollectionsTest.java
+++ b/common/src/test/java/org/opennms/integration/api/v1/util/ImmutableCollectionsTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/common/src/test/java/org/opennms/integration/api/v1/util/MutableCollectionsTest.java
+++ b/common/src/test/java/org/opennms/integration/api/v1/util/MutableCollectionsTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClassPathGraphPropertiesLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClassPathGraphPropertiesLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClassPathResourceTypesLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClassPathResourceTypesLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathCollectorConfigurationLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathCollectorConfigurationLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathEventDefinitionLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathEventDefinitionLoader.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathPollerConfigurationLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathPollerConfigurationLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathSnmpDataCollectionLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathSnmpDataCollectionLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathSyslogMatchLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathSyslogMatchLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathThreshdConfigurationLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathThreshdConfigurationLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathThresholdingConfigLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathThresholdingConfigLoader.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ClasspathXmlLoader.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ClasspathXmlLoader.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/ConfigUtils.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/ConfigUtils.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- * 
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/GraphPropertiesParser.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/GraphPropertiesParser.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/JaxbUtils.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/JaxbUtils.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/collector/AddressRangeXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/collector/AddressRangeXml.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/collector/CollectorConfigurationXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/collector/CollectorConfigurationXml.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/collector/CollectorXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/collector/CollectorXml.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/collector/PackageXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/collector/PackageXml.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/collector/ParameterXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/collector/ParameterXml.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/collector/ServiceXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/collector/ServiceXml.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/Collect.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/Collect.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/DatacollectionGroup.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/DatacollectionGroup.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/Group.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/Group.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/IpList.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/IpList.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/MibObj.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/MibObj.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/MibObjProperty.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/MibObjProperty.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/Parameter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/PersistenceSelectorStrategy.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/PersistenceSelectorStrategy.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/ResourceType.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/ResourceType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/ResourceTypes.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/ResourceTypes.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/StorageStrategy.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/StorageStrategy.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/SystemDef.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/SystemDef.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/SystemDefChoice.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/datacollection/SystemDefChoice.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/AlarmData.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/AlarmData.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Autoacknowledge.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Autoacknowledge.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Autoaction.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Autoaction.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/CollectionGroup.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/CollectionGroup.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Correlation.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Correlation.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Decode.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Decode.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Event.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Event.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/EventLabelComparator.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/EventLabelComparator.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/EventOrdering.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/EventOrdering.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Events.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Events.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Filter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Filter.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Forward.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Forward.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Global.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Global.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/LogDestType.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/LogDestType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Logmsg.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Logmsg.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/ManagedObject.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/ManagedObject.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Mask.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Mask.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Maskelement.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Maskelement.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/MechanismType.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/MechanismType.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Operaction.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Operaction.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Parameter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/PathType.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/PathType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/PathTypeAdapter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/PathTypeAdapter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Script.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Script.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Security.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Security.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Snmp.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Snmp.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/StateType.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/StateType.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Tticket.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Tticket.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/UpdateField.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/UpdateField.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Varbind.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Varbind.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Varbindsdecode.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/eventconf/Varbindsdecode.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/AddressRangeXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/AddressRangeXml.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/DowntimeXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/DowntimeXml.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/MonitorXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/MonitorXml.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/PackageXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/PackageXml.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/ParameterXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/ParameterXml.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/PollerConfigurationXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/PollerConfigurationXml.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/RrdXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/RrdXml.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/poller/ServiceXml.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/poller/ServiceXml.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/Configuration.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/Configuration.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- * 
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/HideMatch.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/HideMatch.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- * 
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/HostaddrMatch.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/HostaddrMatch.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  * 
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/HostnameMatch.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/HostnameMatch.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  * 
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/Match.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/Match.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- * 
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/ParameterAssignment.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/ParameterAssignment.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  * 
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/ProcessMatch.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/ProcessMatch.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- * 
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/SyslogdConfiguration.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/SyslogdConfiguration.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- * 
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/SyslogdConfigurationGroup.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/SyslogdConfigurationGroup.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
- * 
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/UeiMatch.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/syslog/UeiMatch.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  * 
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  * 
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  * 
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *     http://www.gnu.org/licenses/
+ *     https://www.apache.org/licenses/LICENSE-2.0
  * 
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Basethresholddef.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Basethresholddef.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ExcludeRange.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ExcludeRange.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Expression.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Expression.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Filter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Filter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperator.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperator.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperatorAdapter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/FilterOperatorAdapter.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Group.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Group.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/IncludeRange.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/IncludeRange.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Package.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Package.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Parameter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Parameter.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ResourceFilter.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ResourceFilter.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Service.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Service.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ServiceStatus.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ServiceStatus.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThreshdConfiguration.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThreshdConfiguration.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Threshold.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Threshold.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdType.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdType.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Thresholder.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/Thresholder.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdingConfig.java
+++ b/config/src/main/java/org/opennms/integration/api/xml/schema/thresholding/ThresholdingConfig.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 
     <licenses>
         <license>
-            <name>GNU Affero General Public License</name>
-	    <url>http://www.gnu.org/licenses/agpl.html</url>
+            <name>Apache License, Version 2.0</name>
+	        <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 

--- a/sample/src/main/java/org/opennms/integration/api/sample/AlarmTestContextManager.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/AlarmTestContextManager.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/KeyValueStoreClient.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/KeyValueStoreClient.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyAlarmFeedbackListener.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyAlarmFeedbackListener.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyAlarmLifecycleListener.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyAlarmLifecycleListener.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyAlarmPersisterExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyAlarmPersisterExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyCollectorConfigurationExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyCollectorConfigurationExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyCustomStatusProvider.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyCustomStatusProvider.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyEventConfExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyEventConfExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyGraphContainerProvider.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyGraphContainerProvider.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyGraphPropertiesExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyGraphPropertiesExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyInfoLogger.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyInfoLogger.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyPollerConfigurationExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyPollerConfigurationExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyRequisitionProvider.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyRequisitionProvider.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyResourceTypesExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyResourceTypesExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MySnmpCollectionExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MySnmpCollectionExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MySyslogMatchExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MySyslogMatchExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtension.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyThresholdingConfigExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyThresholdingConfigExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/MyTopologyEdgeConsumer.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/MyTopologyEdgeConsumer.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/RequisitionTestContextManager.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/RequisitionTestContextManager.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/RuntimeInfoLogger.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/RuntimeInfoLogger.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleCollector.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleCollector.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleCollectorFactory.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleCollectorFactory.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleDetector.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleDetector.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleDetectorFactory.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SamplePoller.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SamplePoller.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SamplePollerFactory.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SamplePollerFactory.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleTicketerPlugin.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleTicketerPlugin.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/SampleUIExtension.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/SampleUIExtension.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/AlarmLifecyleHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/AlarmLifecyleHealthCheck.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/ChainedHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/ChainedHealthCheck.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/MinionHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/MinionHealthCheck.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/MyHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/MyHealthCheck.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/RequisitionHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/RequisitionHealthCheck.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/ServiceExtensionHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/ServiceExtensionHealthCheck.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/ServiceExtensionOnMinionHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/ServiceExtensionOnMinionHealthCheck.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/main/java/org/opennms/integration/api/sample/health/UserDefinedLinkHealthCheck.java
+++ b/sample/src/main/java/org/opennms/integration/api/sample/health/UserDefinedLinkHealthCheck.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyCollectorConfigurationExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyCollectorConfigurationExtensionTest.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyEventConfExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyEventConfExtensionTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyGraphPropertiesExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyGraphPropertiesExtensionTest.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyPollerConfigurationExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyPollerConfigurationExtensionTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyResourceTypesExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyResourceTypesExtensionTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MySnmpCollectionExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MySnmpCollectionExtensionTest.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MySyslogMatchExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MySyslogMatchExtensionTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyThreshdConfigurationExtensionTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/sample/src/test/java/org/opennms/integration/api/sample/MyThresholdingConfigExtensionTest.java
+++ b/sample/src/test/java/org/opennms/integration/api/sample/MyThresholdingConfigExtensionTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/AbstractStorageIntegrationTest.java
+++ b/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/AbstractStorageIntegrationTest.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/InMemoryStorage.java
+++ b/test-suites/tss-tests/src/main/java/org/opennms/integration/api/v1/timeseries/InMemoryStorage.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/test-suites/tss-tests/src/test/java/org/opennms/integration/api/v1/timeseries/InMemoryStorageTest.java
+++ b/test-suites/tss-tests/src/test/java/org/opennms/integration/api/v1/timeseries/InMemoryStorageTest.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/utils/src/main/java/org/opennms/integration/api/utils/ByteArrayComparator.java
+++ b/utils/src/main/java/org/opennms/integration/api/utils/ByteArrayComparator.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/utils/src/main/java/org/opennms/integration/api/utils/IPLike.java
+++ b/utils/src/main/java/org/opennms/integration/api/utils/IPLike.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/utils/src/main/java/org/opennms/integration/api/utils/InetAddressUtils.java
+++ b/utils/src/main/java/org/opennms/integration/api/utils/InetAddressUtils.java
@@ -7,18 +7,17 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>

--- a/utils/src/test/java/org/opennms/integration/api/utils/InetAddressUtilsTest.java
+++ b/utils/src/test/java/org/opennms/integration/api/utils/InetAddressUtilsTest.java
@@ -7,18 +7,19 @@
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License,
- * or (at your option) any later version.
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ 
  *
  * OpenNMS(R) is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * Apache License Version 2.0 for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
+ * You should have received a copy of the Apache License Version 2.0
  * along with OpenNMS(R).  If not, see:
- *      http://www.gnu.org/licenses/
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * For more information contact:
  *     OpenNMS(R) Licensing <license@opennms.org>


### PR DESCRIPTION
This PR is about cleaning up headers and the pom.xml so that the Apache 2.0 license is correctly reflected in the SBOM license information.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/OIA-59

