### PR TITLE
UIExtension: add optional getGlobalModuleFileName() for persistent page-level overlays

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/ui/UIExtension.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/ui/UIExtension.java
@@ -58,4 +58,18 @@ public interface UIExtension {
      * @return return the implementation class used to lookup OSGI bundle
      */
     Class<? extends UIExtension> getExtensionClass();
+
+    /**
+     * Optional second module that the OpenNMS shell mounts globally (via Teleport to body)
+     * so it is visible on every page, not just under Plugins &gt; menu entry.
+     * <p>
+     * Return {@code null} (the default) if the plugin has no global component. Old OpenNMS
+     * versions that do not recognise this method will simply never mount the global module,
+     * so existing behaviour is fully preserved.
+     *
+     * @return the Vue3 ES-module file name for the global overlay, or {@code null}
+     */
+    default String getGlobalModuleFileName() {
+        return null;
+    }
 }


### PR DESCRIPTION
ALEC-302

## Summary

Adds a single default method to the `UIExtension` interface so that a plugin can register a second Vue3 module to be mounted globally (on every OpenNMS page), rather than only under its Plugins > menu route.

- `getGlobalModuleFileName()` — returns the ES-module file name for a global overlay component, or `null` (default) if the plugin has none.

## Why

Some plugins need UI components that persist across page navigation — e.g. a floating chatbot widget, a notification rail, or a live status indicator. The current `UIExtension` contract only supports a single module loaded at the plugin route; there is no way to inject a component at the application shell level without this hook.

## Backward compatibility

- **All existing implementations compile without changes** — the method is `default` returning `null`.
- **Old OpenNMS versions** that do not call the method never attempt to mount the global module; all plugin functionality is fully unchanged.
- **New OpenNMS** (companion PR #8602) checks for a non-null `globalModuleFileName` in the `/rest/plugins` response and mounts it via `<Teleport to="body">` in the root `App.vue`, so it is visible on every page.

## Companion PRs

- OpenNMS shell: OpenNMS/opennms#8602 — `App.vue` + `GlobalPlugin.vue` + TypeScript type update
- First consumer: ALEC-302 — ALEC context-aware chatbot overlay