### PR TITLE
NMS-20219: Add MCP support for OpenNMS

### DIFF
--- a/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolContext.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolContext.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.mcp;
+
+import java.util.Map;
+
+import org.opennms.integration.api.v1.annotations.Consumable;
+
+/**
+ * The context of a single {@link McpToolProvider} invocation: the tool
+ * arguments and the identity of the authenticated caller, so tools can
+ * authorize per user and record who performed an action.
+ *
+ * @since 2.1.0
+ */
+@Consumable
+public interface McpToolContext {
+
+    /**
+     * @return the tool arguments as parsed JSON (values are String, Number,
+     *         Boolean, List or Map); never null, may be empty
+     */
+    Map<String, Object> getArguments();
+
+    /**
+     * @return the name of the authenticated user invoking the tool, or null
+     *         if no user identity is available
+     */
+    String getUserName();
+
+    /**
+     * @param role the security role to test, e.g. "ROLE_ADMIN"
+     * @return true if the authenticated caller has the given role
+     */
+    boolean isUserInRole(String role);
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolProvider.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolProvider.java
@@ -27,8 +27,6 @@
 
 package org.opennms.integration.api.v1.mcp;
 
-import java.util.Map;
-
 import org.opennms.integration.api.v1.annotations.Exposable;
 
 /**
@@ -72,11 +70,12 @@ public interface McpToolProvider {
      *
      * Implementations should report tool-level failures (bad arguments, lookups
      * that fail) by returning a result with {@code isError=true} rather than
-     * throwing; thrown exceptions are converted to error results by the server.
+     * throwing; thrown exceptions and null returns are converted to error
+     * results by the server.
      *
-     * @param arguments the tool arguments as parsed JSON (values are String,
-     *                  Number, Boolean, List or Map); never null, may be empty
+     * @param context the invocation context carrying the tool arguments and
+     *                the authenticated caller's identity; never null
      * @return the tool result; must not be null
      */
-    McpToolResult execute(Map<String, Object> arguments);
+    McpToolResult execute(McpToolContext context);
 }

--- a/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolProvider.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolProvider.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.mcp;
+
+import java.util.Map;
+
+import org.opennms.integration.api.v1.annotations.Exposable;
+
+/**
+ * Exposes a tool to Model Context Protocol (MCP) clients.
+ *
+ * Implementations registered as OSGi services are picked up by the MCP server
+ * and advertised via {@code tools/list}, and invoked via {@code tools/call}.
+ *
+ * @since 2.1.0
+ */
+@Exposable
+public interface McpToolProvider {
+
+    /**
+     * @return the unique tool name, e.g. "list_nodes". Should be a short
+     *         snake_case identifier that is safe to use in an HTTP header value.
+     */
+    String getToolName();
+
+    /**
+     * @return a human/LLM readable description of what the tool does
+     */
+    String getToolDescription();
+
+    /**
+     * @return the JSON Schema (2020-12) document describing the tool's arguments,
+     *         serialized as a string. Must describe an object type.
+     */
+    String getInputSchema();
+
+    /**
+     * @return true if executing this tool changes state on the OpenNMS server.
+     *         Write tools are only offered to users with administrative privileges.
+     */
+    default boolean isWriteAccess() {
+        return false;
+    }
+
+    /**
+     * Execute the tool.
+     *
+     * Implementations should report tool-level failures (bad arguments, lookups
+     * that fail) by returning a result with {@code isError=true} rather than
+     * throwing; thrown exceptions are converted to error results by the server.
+     *
+     * @param arguments the tool arguments as parsed JSON (values are String,
+     *                  Number, Boolean, List or Map); never null, may be empty
+     * @return the tool result; must not be null
+     */
+    McpToolResult execute(Map<String, Object> arguments);
+}

--- a/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolResult.java
+++ b/api/src/main/java/org/opennms/integration/api/v1/mcp/McpToolResult.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.v1.mcp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The result of executing a {@link McpToolProvider} tool: one or more text
+ * content blocks and an error flag.
+ *
+ * @since 2.1.0
+ */
+public final class McpToolResult {
+    private final List<String> textContents;
+    private final boolean error;
+
+    private McpToolResult(Builder builder) {
+        this.textContents = Collections.unmodifiableList(new ArrayList<>(builder.textContents));
+        this.error = builder.error;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Convenience factory for a successful single text result.
+     */
+    public static McpToolResult text(String text) {
+        return newBuilder().addText(text).build();
+    }
+
+    /**
+     * Convenience factory for a failed single text result.
+     */
+    public static McpToolResult error(String text) {
+        return newBuilder().addText(text).setError(true).build();
+    }
+
+    public List<String> getTextContents() {
+        return textContents;
+    }
+
+    public boolean isError() {
+        return error;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final McpToolResult that = (McpToolResult) o;
+        return error == that.error && Objects.equals(textContents, that.textContents);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(textContents, error);
+    }
+
+    @Override
+    public String toString() {
+        return "McpToolResult{textContents=" + textContents + ", error=" + error + "}";
+    }
+
+    public static final class Builder {
+        private final List<String> textContents = new ArrayList<>();
+        private boolean error;
+
+        private Builder() {
+        }
+
+        public Builder addText(String text) {
+            this.textContents.add(Objects.requireNonNull(text));
+            return this;
+        }
+
+        public Builder setError(boolean error) {
+            this.error = error;
+            return this;
+        }
+
+        public McpToolResult build() {
+            if (textContents.isEmpty()) {
+                throw new IllegalStateException("At least one text content block is required");
+            }
+            return new McpToolResult(this);
+        }
+    }
+}

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -29,4 +29,15 @@
         <bundle>blueprint:mvn:org.opennms.integration.api.sample/sample-project/${project.version}/xml/blueprint-sentinel</bundle>
     </feature>
 
+    <feature name="opennms-mcp-server" description="OpenNMS MCP Server" version="${project.version}">
+        <!-- No version on purpose: the Integration API feature bundled with the
+             OpenNMS container satisfies this; the mcp-server bundle embeds the
+             v1.mcp extension point it needs beyond that. -->
+        <feature dependency="true">opennms-integration-api</feature>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson.version}</bundle>
+        <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
+        <bundle>mvn:org.opennms.integration.api/mcp-server/${project.version}</bundle>
+    </feature>
+
 </features>

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,52 @@
+# OpenNMS MCP Server
+
+Exposes OpenNMS to [Model Context Protocol](https://modelcontextprotocol.io) (MCP) clients
+such as Claude Code, implementing the stateless protocol revision **2026-07-28**
+(Streamable HTTP, plain JSON request/response).
+
+## Installation
+
+From the OpenNMS Karaf shell (`ssh -p 8101 admin@localhost`):
+
+```
+feature:repo-add mvn:org.opennms.integration.api/karaf-features/2.0.1-SNAPSHOT/xml
+feature:install opennms-mcp-server
+```
+
+The MCP endpoint is then available at `http://<opennms>:8980/opennms/rest/mcp`, behind
+the regular OpenNMS REST authentication (HTTP basic auth, stateless; the user needs the
+`ROLE_REST` or `ROLE_ADMIN` role). Example Claude Code configuration:
+
+```
+claude mcp add --transport http opennms http://localhost:8980/opennms/rest/mcp \
+    --header "Authorization: Basic $(echo -n admin:admin | base64)"
+```
+
+## Built-in tools
+
+| Tool | Access | Description |
+| --- | --- | --- |
+| `list_nodes` | read | List/search the node inventory |
+| `get_node` | read | Node details including IP interfaces and services |
+| `list_alarms` | read | List alarms, filtered by severity/acknowledgement |
+| `find_node_by_ip` | read | Resolve an IP address to a node |
+| `update_alarms` | write | Acknowledge/unacknowledge/escalate/clear alarms |
+| `send_event` | write | Send an event onto the event bus |
+
+Read tools are available to any user allowed to POST to the REST API (`ROLE_REST` or
+`ROLE_ADMIN`); write tools additionally require the `ROLE_ADMIN` role.
+
+## Contributing tools from other plugins
+
+Any plugin can contribute tools by publishing an
+`org.opennms.integration.api.v1.mcp.McpToolProvider` OSGi service; the server picks
+them up dynamically and advertises them via `tools/list`.
+
+## Protocol notes
+
+* Only the stateless 2026-07-28 revision is served: no `initialize` handshake, no
+  `Mcp-Session-Id`, no GET/SSE endpoint. Requests must carry the
+  `MCP-Protocol-Version`, `Mcp-Method` and (for `tools/call`) `Mcp-Name` headers.
+* Legacy (2025-11-25 and earlier) clients receive an error naming the supported
+  protocol versions.
+* `subscriptions/listen` (server push) and MRTR are not implemented.

--- a/mcp-server/pom.xml
+++ b/mcp-server/pom.xml
@@ -1,0 +1,92 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.opennms.integration.api</groupId>
+        <artifactId>api-project</artifactId>
+        <version>2.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>mcp-server</artifactId>
+    <name>OpenNMS Integration API :: MCP Server</name>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <!-- Embed and export the v1.mcp extension point so this bundle
+                             installs on OpenNMS releases whose bundled Integration API
+                             does not export it yet. The import stays substitutable, so
+                             once a bundled API release exports the package the resolver
+                             can wire everyone to that copy instead. -->
+                        <Export-Package>
+                            org.opennms.integration.api.v1.mcp;version="${project.version}",
+                            org.opennms.integration.api.mcpserver*;version="${project.version}"
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.opennms.integration.api</groupId>
+            <artifactId>api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.integration.api</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>${osgiVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Provided by the OpenNMS container at runtime -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpCaller.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpCaller.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * The authenticated caller of an MCP request: user name and role membership,
+ * as established by the container security layer before the request reached
+ * the MCP endpoint.
+ */
+public final class McpCaller {
+    private final String userName;
+    private final Predicate<String> roleChecker;
+
+    public McpCaller(String userName, Predicate<String> roleChecker) {
+        this.userName = userName;
+        this.roleChecker = Objects.requireNonNull(roleChecker);
+    }
+
+    /** @return the authenticated user name, or null if unavailable */
+    public String getUserName() {
+        return userName;
+    }
+
+    public boolean isUserInRole(String role) {
+        return roleChecker.test(role);
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRequestHandler.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRequestHandler.java
@@ -31,8 +31,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 import org.osgi.framework.Bundle;
@@ -41,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -49,18 +52,23 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 /**
  * Transport-neutral request handler implementing the stateless MCP protocol
  * (revision 2026-07-28) for a tools-only server: server/discover, tools/list
- * and tools/call over single JSON-RPC 2.0 messages.
+ * and tools/call over single JSON-RPC 2.0 messages. Legacy (2025-03-26 through
+ * 2025-11-25) clients are served in dual-era mode via a stateless initialize
+ * handshake.
  */
 public class McpRequestHandler {
     private static final Logger LOG = LoggerFactory.getLogger(McpRequestHandler.class);
+    private static final Logger AUDIT_LOG = LoggerFactory.getLogger("org.opennms.integration.api.mcpserver.audit");
 
     public static final String PROTOCOL_VERSION = "2026-07-28";
     public static final String SERVER_NAME = "OpenNMS MCP Server";
 
     /** Legacy (initialize-handshake) revisions served in dual-era mode, all statelessly. */
-    static final java.util.Set<String> LEGACY_VERSIONS =
-            java.util.Set.of("2025-03-26", "2025-06-18", "2025-11-25");
+    static final Set<String> LEGACY_VERSIONS = Set.of("2025-03-26", "2025-06-18", "2025-11-25");
     static final String DEFAULT_LEGACY_VERSION = "2025-06-18";
+
+    static final String ROLE_ADMIN = "ROLE_ADMIN";
+    static final String ROLE_READONLY = "ROLE_READONLY";
 
     private static final String INSTRUCTIONS =
             "Provides tools to inspect and operate this OpenNMS network monitoring "
@@ -86,6 +94,7 @@ public class McpRequestHandler {
 
     private static final String BASE64_SENTINEL_PREFIX = "=?base64?";
     private static final String BASE64_SENTINEL_SUFFIX = "?=";
+    private static final String X_MCP_HEADER = "x-mcp-header";
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final ToolRegistry toolRegistry;
@@ -123,9 +132,18 @@ public class McpRequestHandler {
      *
      * @param body the raw request body
      * @param headers case-insensitive header lookup (e.g. HttpServletRequest::getHeader)
-     * @param canWrite whether the authenticated user may invoke write tools
+     * @param caller the authenticated caller
      */
-    public Result handle(String body, Function<String, String> headers, boolean canWrite) {
+    public Result handle(String body, Function<String, String> headers, McpCaller caller) {
+        try {
+            return doHandle(body, headers, caller);
+        } catch (RuntimeException e) {
+            LOG.error("Unexpected error handling MCP request", e);
+            return error(500, null, INTERNAL_ERROR, "Internal error");
+        }
+    }
+
+    private Result doHandle(String body, Function<String, String> headers, McpCaller caller) {
         final JsonNode root;
         try {
             root = mapper.readTree(body);
@@ -163,12 +181,17 @@ public class McpRequestHandler {
             return json(200, response(id, legacyInitialize(params)));
         }
         if (!modern) {
-            // Legacy-era request: the modern per-request _meta and the
-            // Mcp-Method/Mcp-Name/MCP-Protocol-Version header rules do not apply.
-            return legacyDispatch(method, id, params, canWrite);
+            // Legacy-era request: the modern _meta requirements do not apply, but any
+            // MCP headers that ARE present must still be consistent with the body so
+            // that intermediaries routing on headers cannot be fed a different truth.
+            final Result headerFailure = validateLegacyHeaders(method, id, params, headers);
+            if (headerFailure != null) {
+                return headerFailure;
+            }
+            return legacyDispatch(method, id, params, caller);
         }
 
-        // Header/body validation per the Streamable HTTP transport
+        // Header/body validation per the Streamable HTTP transport (modern era)
         final String mcpMethod = headers.apply(HEADER_METHOD);
         if (mcpMethod == null) {
             return error(400, id, HEADER_MISMATCH, "Missing required header: " + HEADER_METHOD);
@@ -216,12 +239,45 @@ public class McpRequestHandler {
             case "server/discover":
                 return json(200, response(id, discover()));
             case "tools/list":
-                return json(200, response(id, toolsList(canWrite)));
+                return json(200, response(id, toolsList(caller)));
             case "tools/call":
-                return toolsCall(id, params, canWrite, true);
+                return toolsCall(id, params, caller, true);
             default:
                 return error(404, id, METHOD_NOT_FOUND, "Method not found: " + method);
         }
+    }
+
+    /**
+     * Legacy-era requests do not require the modern headers, but if a client or
+     * intermediary put them on the wire anyway, they must not contradict the body.
+     * A modern protocol version header without modern _meta is likewise rejected
+     * so validation cannot be bypassed by dropping the _meta field.
+     */
+    private Result validateLegacyHeaders(String method, JsonNode id, JsonNode params,
+                                         Function<String, String> headers) {
+        final String protocolHeader = headers.apply(HEADER_PROTOCOL_VERSION);
+        if (protocolHeader != null && !LEGACY_VERSIONS.contains(protocolHeader)) {
+            return error(400, id, HEADER_MISMATCH, String.format(
+                    "Header mismatch: %s header value '%s' requires the matching "
+                            + "'%s' field in params._meta", HEADER_PROTOCOL_VERSION,
+                    protocolHeader, META_PROTOCOL_VERSION));
+        }
+        final String mcpMethod = headers.apply(HEADER_METHOD);
+        if (mcpMethod != null && !mcpMethod.equals(method)) {
+            return error(400, id, HEADER_MISMATCH, String.format(
+                    "Header mismatch: %s header value '%s' does not match body value '%s'",
+                    HEADER_METHOD, mcpMethod, method));
+        }
+        if ("tools/call".equals(method)) {
+            final String mcpName = decodeSentinel(headers.apply(HEADER_NAME));
+            final String name = params.path("name").asText(null);
+            if (mcpName != null && !mcpName.equals(name)) {
+                return error(400, id, HEADER_MISMATCH, String.format(
+                        "Header mismatch: %s header value '%s' does not match body value '%s'",
+                        HEADER_NAME, mcpName, name));
+            }
+        }
+        return null;
     }
 
     private ObjectNode legacyInitialize(JsonNode params) {
@@ -239,17 +295,17 @@ public class McpRequestHandler {
         return result;
     }
 
-    private Result legacyDispatch(String method, JsonNode id, JsonNode params, boolean canWrite) {
+    private Result legacyDispatch(String method, JsonNode id, JsonNode params, McpCaller caller) {
         switch (method) {
             case "ping":
                 return json(200, response(id, mapper.createObjectNode()));
             case "tools/list": {
                 final ObjectNode result = mapper.createObjectNode();
-                result.set("tools", toolsArray(canWrite));
+                result.set("tools", toolsArray(caller));
                 return json(200, response(id, result));
             }
             case "tools/call":
-                return toolsCall(id, params, canWrite, false);
+                return toolsCall(id, params, caller, false);
             default:
                 return error(200, id, METHOD_NOT_FOUND, "Method not found: " + method);
         }
@@ -267,42 +323,55 @@ public class McpRequestHandler {
         return result;
     }
 
-    private ObjectNode toolsList(boolean canWrite) {
+    private ObjectNode toolsList(McpCaller caller) {
         final ObjectNode result = mapper.createObjectNode();
         result.put("resultType", "complete");
-        result.set("tools", toolsArray(canWrite));
+        result.set("tools", toolsArray(caller));
         result.put("ttlMs", 60000L);
         result.put("cacheScope", "private");
         addServerInfo(result);
         return result;
     }
 
-    private ArrayNode toolsArray(boolean canWrite) {
+    private ArrayNode toolsArray(McpCaller caller) {
+        final boolean canWrite = canWrite(caller);
         final ArrayNode tools = mapper.createArrayNode();
         for (McpToolProvider tool : toolRegistry.getTools()) {
-            if (tool.isWriteAccess() && !canWrite) {
-                // Write tools are only offered to administrators; advertising them
-                // to read-only users would invite calls that are always rejected.
-                continue;
+            // One misbehaving provider must not break the listing for everyone.
+            try {
+                if (tool.isWriteAccess() && !canWrite) {
+                    // Write tools are only offered to administrators; advertising them
+                    // to read-only users would invite calls that are always rejected.
+                    continue;
+                }
+                final JsonNode schema = parseSchema(tool);
+                if (schema == null) {
+                    continue;
+                }
+                final ObjectNode toolNode = mapper.createObjectNode();
+                toolNode.put("name", tool.getToolName());
+                toolNode.put("description", tool.getToolDescription());
+                toolNode.set("inputSchema", schema);
+                tools.add(toolNode);
+            } catch (RuntimeException e) {
+                LOG.warn("Skipping misbehaving MCP tool provider {}", tool.getClass().getName(), e);
             }
-            final ObjectNode toolNode = tools.addObject();
-            toolNode.put("name", tool.getToolName());
-            toolNode.put("description", tool.getToolDescription());
-            toolNode.set("inputSchema", parseSchema(tool));
         }
         return tools;
     }
 
-    private Result toolsCall(JsonNode id, JsonNode params, boolean canWrite, boolean modern) {
+    private Result toolsCall(JsonNode id, JsonNode params, McpCaller caller, boolean modern) {
         final String name = params.path("name").asText(null);
         if (name == null) {
             return error(200, id, INVALID_PARAMS, "Missing required parameter: name");
         }
         final McpToolProvider tool = toolRegistry.getTool(name);
-        if (tool == null) {
+        if (tool == null || parseSchema(tool) == null) {
             return error(200, id, INVALID_PARAMS, "Unknown tool: " + name);
         }
-        if (tool.isWriteAccess() && !canWrite) {
+        if (tool.isWriteAccess() && !canWrite(caller)) {
+            AUDIT_LOG.warn("MCP tools/call denied: user='{}' tool='{}' (requires administrative access)",
+                    caller.getUserName(), name);
             return error(200, id, INSUFFICIENT_PRIVILEGES,
                     "Insufficient privileges: tool '" + name + "' requires administrative access");
         }
@@ -311,7 +380,7 @@ public class McpRequestHandler {
         try {
             final JsonNode argsNode = params.path("arguments");
             arguments = argsNode.isObject()
-                    ? mapper.convertValue(argsNode, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {})
+                    ? mapper.convertValue(argsNode, new TypeReference<Map<String, Object>>() {})
                     : Map.of();
         } catch (IllegalArgumentException e) {
             return error(200, id, INVALID_PARAMS, "Invalid tool arguments: " + e.getMessage());
@@ -319,11 +388,18 @@ public class McpRequestHandler {
 
         McpToolResult toolResult;
         try {
-            toolResult = tool.execute(arguments);
+            toolResult = tool.execute(new ToolContext(arguments, caller));
+            if (toolResult == null) {
+                LOG.warn("Tool '{}' returned null", name);
+                toolResult = McpToolResult.error("Tool execution failed: no result");
+            }
         } catch (Exception e) {
             LOG.warn("Tool '{}' threw while executing", name, e);
             toolResult = McpToolResult.error("Tool execution failed: " + e.getMessage());
         }
+
+        AUDIT_LOG.info("MCP tools/call: user='{}' tool='{}' arguments={} isError={}",
+                caller.getUserName(), name, toJsonSafe(arguments), toolResult.isError());
 
         final ObjectNode result = mapper.createObjectNode();
         if (modern) {
@@ -342,19 +418,88 @@ public class McpRequestHandler {
         return json(200, response(id, result));
     }
 
+    static boolean canWrite(McpCaller caller) {
+        // Mirrors the REST API's write rules: administrative access, and the
+        // ROLE_READONLY marker role revokes write access even for admins.
+        return caller.isUserInRole(ROLE_ADMIN) && !caller.isUserInRole(ROLE_READONLY);
+    }
+
+    /**
+     * Parses and vets a tool's input schema. Returns null if the tool must not
+     * be served: schemas declaring x-mcp-header are rejected because this server
+     * does not validate Mcp-Param-* headers against the body, and serving such a
+     * tool would let intermediaries authorize on unvalidated header values.
+     * Schemas that are unparseable (but present) fall back to an open schema.
+     */
     private JsonNode parseSchema(McpToolProvider tool) {
+        final String schemaString;
         try {
-            final JsonNode schema = mapper.readTree(tool.getInputSchema());
-            if (schema != null && schema.isObject()) {
-                return schema;
+            schemaString = tool.getInputSchema();
+        } catch (RuntimeException e) {
+            LOG.warn("Tool '{}' threw while providing its input schema", safeToolName(tool), e);
+            return null;
+        }
+        if (schemaString == null) {
+            LOG.warn("Tool '{}' declares no input schema, not serving it", safeToolName(tool));
+            return null;
+        }
+        JsonNode schema = null;
+        try {
+            final JsonNode parsed = mapper.readTree(schemaString);
+            if (parsed != null && parsed.isObject()) {
+                schema = parsed;
             }
         } catch (JsonProcessingException e) {
             LOG.warn("Tool '{}' declares an invalid input schema, advertising an open schema instead",
-                    tool.getToolName(), e);
+                    safeToolName(tool), e);
         }
-        final ObjectNode fallback = mapper.createObjectNode();
-        fallback.put("type", "object");
-        return fallback;
+        if (schema == null) {
+            final ObjectNode fallback = mapper.createObjectNode();
+            fallback.put("type", "object");
+            return fallback;
+        }
+        if (containsField(schema, X_MCP_HEADER)) {
+            LOG.warn("Tool '{}' declares {} in its input schema, which this server does not support; "
+                    + "not serving it", safeToolName(tool), X_MCP_HEADER);
+            return null;
+        }
+        return schema;
+    }
+
+    private static boolean containsField(JsonNode node, String fieldName) {
+        if (node.isObject()) {
+            if (node.has(fieldName)) {
+                return true;
+            }
+            for (JsonNode child : node) {
+                if (containsField(child, fieldName)) {
+                    return true;
+                }
+            }
+        } else if (node.isArray()) {
+            for (JsonNode child : node) {
+                if (containsField(child, fieldName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String safeToolName(McpToolProvider tool) {
+        try {
+            return tool.getToolName();
+        } catch (RuntimeException e) {
+            return tool.getClass().getName();
+        }
+    }
+
+    private String toJsonSafe(Map<String, Object> arguments) {
+        try {
+            return mapper.writeValueAsString(arguments);
+        } catch (JsonProcessingException e) {
+            return String.valueOf(arguments);
+        }
     }
 
     private void addServerInfo(ObjectNode result) {
@@ -423,5 +568,30 @@ public class McpRequestHandler {
             // running outside OSGi (unit tests)
         }
         return "dev";
+    }
+
+    private static final class ToolContext implements McpToolContext {
+        private final Map<String, Object> arguments;
+        private final McpCaller caller;
+
+        ToolContext(Map<String, Object> arguments, McpCaller caller) {
+            this.arguments = arguments;
+            this.caller = caller;
+        }
+
+        @Override
+        public Map<String, Object> getArguments() {
+            return arguments;
+        }
+
+        @Override
+        public String getUserName() {
+            return caller.getUserName();
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            return caller.isUserInRole(role);
+        }
     }
 }

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRequestHandler.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRequestHandler.java
@@ -58,7 +58,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class McpRequestHandler {
     private static final Logger LOG = LoggerFactory.getLogger(McpRequestHandler.class);
-    private static final Logger AUDIT_LOG = LoggerFactory.getLogger("org.opennms.integration.api.mcpserver.audit");
+    // Child of the container's "audit" logger, which routes to the security audit
+    // log (data/security/audit.log in Karaf) regardless of application log levels.
+    private static final Logger AUDIT_LOG = LoggerFactory.getLogger("audit.mcp");
 
     public static final String PROTOCOL_VERSION = "2026-07-28";
     public static final String SERVER_NAME = "OpenNMS MCP Server";
@@ -393,13 +395,20 @@ public class McpRequestHandler {
                 LOG.warn("Tool '{}' returned null", name);
                 toolResult = McpToolResult.error("Tool execution failed: no result");
             }
+        } catch (IllegalArgumentException e) {
+            // Argument validation errors are authored by the tool and safe to surface
+            LOG.warn("Tool '{}' rejected its arguments: {}", name, e.getMessage());
+            toolResult = McpToolResult.error("Invalid tool arguments: " + e.getMessage());
         } catch (Exception e) {
+            // Unexpected failures stay in the server log; the message may leak internals
             LOG.warn("Tool '{}' threw while executing", name, e);
-            toolResult = McpToolResult.error("Tool execution failed: " + e.getMessage());
+            toolResult = McpToolResult.error("Tool execution failed; see the server log for details");
         }
 
-        AUDIT_LOG.info("MCP tools/call: user='{}' tool='{}' arguments={} isError={}",
-                caller.getUserName(), name, toJsonSafe(arguments), toolResult.isError());
+        // Argument values may contain secrets (event parameters, contributed tool
+        // inputs), so the audit trail records only the argument names.
+        AUDIT_LOG.info("MCP tools/call: user='{}' tool='{}' argumentKeys={} isError={}",
+                caller.getUserName(), name, arguments.keySet(), toolResult.isError());
 
         final ObjectNode result = mapper.createObjectNode();
         if (modern) {
@@ -491,14 +500,6 @@ public class McpRequestHandler {
             return tool.getToolName();
         } catch (RuntimeException e) {
             return tool.getClass().getName();
-        }
-    }
-
-    private String toJsonSafe(Map<String, Object> arguments) {
-        try {
-            return mapper.writeValueAsString(arguments);
-        } catch (JsonProcessingException e) {
-            return String.valueOf(arguments);
         }
     }
 

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRequestHandler.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRequestHandler.java
@@ -1,0 +1,427 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Transport-neutral request handler implementing the stateless MCP protocol
+ * (revision 2026-07-28) for a tools-only server: server/discover, tools/list
+ * and tools/call over single JSON-RPC 2.0 messages.
+ */
+public class McpRequestHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(McpRequestHandler.class);
+
+    public static final String PROTOCOL_VERSION = "2026-07-28";
+    public static final String SERVER_NAME = "OpenNMS MCP Server";
+
+    /** Legacy (initialize-handshake) revisions served in dual-era mode, all statelessly. */
+    static final java.util.Set<String> LEGACY_VERSIONS =
+            java.util.Set.of("2025-03-26", "2025-06-18", "2025-11-25");
+    static final String DEFAULT_LEGACY_VERSION = "2025-06-18";
+
+    private static final String INSTRUCTIONS =
+            "Provides tools to inspect and operate this OpenNMS network monitoring "
+                    + "server: query the node inventory and alarms, resolve IP addresses to nodes, "
+                    + "acknowledge alarms and send events.";
+
+    public static final String HEADER_PROTOCOL_VERSION = "MCP-Protocol-Version";
+    public static final String HEADER_METHOD = "Mcp-Method";
+    public static final String HEADER_NAME = "Mcp-Name";
+
+    static final String META_PROTOCOL_VERSION = "io.modelcontextprotocol/protocolVersion";
+    static final String META_SERVER_INFO = "io.modelcontextprotocol/serverInfo";
+
+    // JSON-RPC / MCP error codes
+    static final int PARSE_ERROR = -32700;
+    static final int INVALID_REQUEST = -32600;
+    static final int METHOD_NOT_FOUND = -32601;
+    static final int INVALID_PARAMS = -32602;
+    static final int INTERNAL_ERROR = -32603;
+    static final int INSUFFICIENT_PRIVILEGES = -32000; // implementation-defined range
+    static final int HEADER_MISMATCH = -32020;
+    static final int UNSUPPORTED_PROTOCOL_VERSION = -32022;
+
+    private static final String BASE64_SENTINEL_PREFIX = "=?base64?";
+    private static final String BASE64_SENTINEL_SUFFIX = "?=";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ToolRegistry toolRegistry;
+    private final String serverVersion;
+
+    public McpRequestHandler(ToolRegistry toolRegistry) {
+        this.toolRegistry = Objects.requireNonNull(toolRegistry);
+        this.serverVersion = lookupBundleVersion();
+    }
+
+    /**
+     * The outcome of handling one MCP message: the HTTP status to answer with
+     * and the JSON body (null for responses without a body, e.g. 202).
+     */
+    public static final class Result {
+        private final int httpStatus;
+        private final String body;
+
+        Result(int httpStatus, String body) {
+            this.httpStatus = httpStatus;
+            this.body = body;
+        }
+
+        public int getHttpStatus() {
+            return httpStatus;
+        }
+
+        public String getBody() {
+            return body;
+        }
+    }
+
+    /**
+     * Handle a single JSON-RPC message POSTed to the MCP endpoint.
+     *
+     * @param body the raw request body
+     * @param headers case-insensitive header lookup (e.g. HttpServletRequest::getHeader)
+     * @param canWrite whether the authenticated user may invoke write tools
+     */
+    public Result handle(String body, Function<String, String> headers, boolean canWrite) {
+        final JsonNode root;
+        try {
+            root = mapper.readTree(body);
+        } catch (JsonProcessingException e) {
+            return error(400, null, PARSE_ERROR, "Parse error: " + e.getOriginalMessage());
+        }
+
+        if (root == null || !root.isObject() || !"2.0".equals(root.path("jsonrpc").asText())
+                || !root.path("method").isTextual()) {
+            return error(400, null, INVALID_REQUEST, "Invalid JSON-RPC 2.0 request");
+        }
+
+        final String method = root.get("method").asText();
+        final JsonNode id = root.get("id");
+        if (id == null) {
+            // Notification (no id member): accept and ignore. The 2026-07-28 core
+            // protocol defines no client-to-server notifications over Streamable
+            // HTTP, but legacy clients may still send notifications/initialized.
+            LOG.debug("Accepted MCP notification: {}", method);
+            return new Result(202, null);
+        }
+        if (id.isNull()) {
+            // JSON-RPC 2.0 distinguishes notifications by an absent id; an explicit
+            // null id is neither a valid request nor a notification.
+            return error(400, null, INVALID_REQUEST, "Request id must not be null");
+        }
+
+        final JsonNode params = root.path("params");
+        final boolean modern = params.path("_meta").has(META_PROTOCOL_VERSION);
+
+        if ("initialize".equals(method)) {
+            // Dual-era support (2026-07-28 versioning rules): an initialize request
+            // selects legacy (2025-11-25 and earlier) semantics. We stay stateless —
+            // no Mcp-Session-Id is minted, which those revisions permit.
+            return json(200, response(id, legacyInitialize(params)));
+        }
+        if (!modern) {
+            // Legacy-era request: the modern per-request _meta and the
+            // Mcp-Method/Mcp-Name/MCP-Protocol-Version header rules do not apply.
+            return legacyDispatch(method, id, params, canWrite);
+        }
+
+        // Header/body validation per the Streamable HTTP transport
+        final String mcpMethod = headers.apply(HEADER_METHOD);
+        if (mcpMethod == null) {
+            return error(400, id, HEADER_MISMATCH, "Missing required header: " + HEADER_METHOD);
+        }
+        if (!mcpMethod.equals(method)) {
+            return error(400, id, HEADER_MISMATCH, String.format(
+                    "Header mismatch: %s header value '%s' does not match body value '%s'",
+                    HEADER_METHOD, mcpMethod, method));
+        }
+
+        final String protocolHeader = headers.apply(HEADER_PROTOCOL_VERSION);
+        if (protocolHeader == null) {
+            return error(400, id, HEADER_MISMATCH, "Missing required header: " + HEADER_PROTOCOL_VERSION);
+        }
+        final String protocolBody = params.path("_meta").path(META_PROTOCOL_VERSION).asText(null);
+        if (!protocolHeader.equals(protocolBody)) {
+            return error(400, id, HEADER_MISMATCH, String.format(
+                    "Header mismatch: %s header value '%s' does not match _meta value '%s'",
+                    HEADER_PROTOCOL_VERSION, protocolHeader, protocolBody));
+        }
+
+        if ("tools/call".equals(method)) {
+            final String name = params.path("name").asText(null);
+            final String mcpName = decodeSentinel(headers.apply(HEADER_NAME));
+            if (mcpName == null) {
+                return error(400, id, HEADER_MISMATCH, "Missing required header: " + HEADER_NAME);
+            }
+            if (!mcpName.equals(name)) {
+                return error(400, id, HEADER_MISMATCH, String.format(
+                        "Header mismatch: %s header value '%s' does not match body value '%s'",
+                        HEADER_NAME, mcpName, name));
+            }
+        }
+
+        // server/discover answers regardless of the requested version so that
+        // clients can learn what this server supports.
+        if (!"server/discover".equals(method) && !PROTOCOL_VERSION.equals(protocolBody)) {
+            final ObjectNode data = mapper.createObjectNode();
+            data.putArray("supported").add(PROTOCOL_VERSION);
+            data.put("requested", protocolBody);
+            return error(400, id, UNSUPPORTED_PROTOCOL_VERSION, "Unsupported protocol version", data);
+        }
+
+        switch (method) {
+            case "server/discover":
+                return json(200, response(id, discover()));
+            case "tools/list":
+                return json(200, response(id, toolsList(canWrite)));
+            case "tools/call":
+                return toolsCall(id, params, canWrite, true);
+            default:
+                return error(404, id, METHOD_NOT_FOUND, "Method not found: " + method);
+        }
+    }
+
+    private ObjectNode legacyInitialize(JsonNode params) {
+        final String requested = params.path("protocolVersion").asText(null);
+        final String negotiated = requested != null && LEGACY_VERSIONS.contains(requested)
+                ? requested
+                : DEFAULT_LEGACY_VERSION;
+        final ObjectNode result = mapper.createObjectNode();
+        result.put("protocolVersion", negotiated);
+        result.putObject("capabilities").putObject("tools").put("listChanged", false);
+        final ObjectNode serverInfo = result.putObject("serverInfo");
+        serverInfo.put("name", SERVER_NAME);
+        serverInfo.put("version", serverVersion);
+        result.put("instructions", INSTRUCTIONS);
+        return result;
+    }
+
+    private Result legacyDispatch(String method, JsonNode id, JsonNode params, boolean canWrite) {
+        switch (method) {
+            case "ping":
+                return json(200, response(id, mapper.createObjectNode()));
+            case "tools/list": {
+                final ObjectNode result = mapper.createObjectNode();
+                result.set("tools", toolsArray(canWrite));
+                return json(200, response(id, result));
+            }
+            case "tools/call":
+                return toolsCall(id, params, canWrite, false);
+            default:
+                return error(200, id, METHOD_NOT_FOUND, "Method not found: " + method);
+        }
+    }
+
+    private ObjectNode discover() {
+        final ObjectNode result = mapper.createObjectNode();
+        result.put("resultType", "complete");
+        result.putArray("supportedVersions").add(PROTOCOL_VERSION);
+        result.putObject("capabilities").putObject("tools");
+        result.put("instructions", INSTRUCTIONS);
+        result.put("ttlMs", 3600000L);
+        result.put("cacheScope", "private");
+        addServerInfo(result);
+        return result;
+    }
+
+    private ObjectNode toolsList(boolean canWrite) {
+        final ObjectNode result = mapper.createObjectNode();
+        result.put("resultType", "complete");
+        result.set("tools", toolsArray(canWrite));
+        result.put("ttlMs", 60000L);
+        result.put("cacheScope", "private");
+        addServerInfo(result);
+        return result;
+    }
+
+    private ArrayNode toolsArray(boolean canWrite) {
+        final ArrayNode tools = mapper.createArrayNode();
+        for (McpToolProvider tool : toolRegistry.getTools()) {
+            if (tool.isWriteAccess() && !canWrite) {
+                // Write tools are only offered to administrators; advertising them
+                // to read-only users would invite calls that are always rejected.
+                continue;
+            }
+            final ObjectNode toolNode = tools.addObject();
+            toolNode.put("name", tool.getToolName());
+            toolNode.put("description", tool.getToolDescription());
+            toolNode.set("inputSchema", parseSchema(tool));
+        }
+        return tools;
+    }
+
+    private Result toolsCall(JsonNode id, JsonNode params, boolean canWrite, boolean modern) {
+        final String name = params.path("name").asText(null);
+        if (name == null) {
+            return error(200, id, INVALID_PARAMS, "Missing required parameter: name");
+        }
+        final McpToolProvider tool = toolRegistry.getTool(name);
+        if (tool == null) {
+            return error(200, id, INVALID_PARAMS, "Unknown tool: " + name);
+        }
+        if (tool.isWriteAccess() && !canWrite) {
+            return error(200, id, INSUFFICIENT_PRIVILEGES,
+                    "Insufficient privileges: tool '" + name + "' requires administrative access");
+        }
+
+        final Map<String, Object> arguments;
+        try {
+            final JsonNode argsNode = params.path("arguments");
+            arguments = argsNode.isObject()
+                    ? mapper.convertValue(argsNode, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {})
+                    : Map.of();
+        } catch (IllegalArgumentException e) {
+            return error(200, id, INVALID_PARAMS, "Invalid tool arguments: " + e.getMessage());
+        }
+
+        McpToolResult toolResult;
+        try {
+            toolResult = tool.execute(arguments);
+        } catch (Exception e) {
+            LOG.warn("Tool '{}' threw while executing", name, e);
+            toolResult = McpToolResult.error("Tool execution failed: " + e.getMessage());
+        }
+
+        final ObjectNode result = mapper.createObjectNode();
+        if (modern) {
+            result.put("resultType", "complete");
+        }
+        final ArrayNode content = result.putArray("content");
+        for (String text : toolResult.getTextContents()) {
+            final ObjectNode block = content.addObject();
+            block.put("type", "text");
+            block.put("text", text);
+        }
+        result.put("isError", toolResult.isError());
+        if (modern) {
+            addServerInfo(result);
+        }
+        return json(200, response(id, result));
+    }
+
+    private JsonNode parseSchema(McpToolProvider tool) {
+        try {
+            final JsonNode schema = mapper.readTree(tool.getInputSchema());
+            if (schema != null && schema.isObject()) {
+                return schema;
+            }
+        } catch (JsonProcessingException e) {
+            LOG.warn("Tool '{}' declares an invalid input schema, advertising an open schema instead",
+                    tool.getToolName(), e);
+        }
+        final ObjectNode fallback = mapper.createObjectNode();
+        fallback.put("type", "object");
+        return fallback;
+    }
+
+    private void addServerInfo(ObjectNode result) {
+        final ObjectNode serverInfo = result.putObject("_meta").putObject(META_SERVER_INFO);
+        serverInfo.put("name", SERVER_NAME);
+        serverInfo.put("version", serverVersion);
+    }
+
+    private ObjectNode response(JsonNode id, ObjectNode result) {
+        final ObjectNode response = mapper.createObjectNode();
+        response.put("jsonrpc", "2.0");
+        response.set("id", id);
+        response.set("result", result);
+        return response;
+    }
+
+    private Result error(int httpStatus, JsonNode id, int code, String message) {
+        return error(httpStatus, id, code, message, null);
+    }
+
+    private Result error(int httpStatus, JsonNode id, int code, String message, JsonNode data) {
+        final ObjectNode response = mapper.createObjectNode();
+        response.put("jsonrpc", "2.0");
+        response.set("id", id == null ? response.nullNode() : id);
+        final ObjectNode error = response.putObject("error");
+        error.put("code", code);
+        error.put("message", message);
+        if (data != null) {
+            error.set("data", data);
+        }
+        return json(httpStatus, response);
+    }
+
+    private Result json(int httpStatus, ObjectNode body) {
+        try {
+            return new Result(httpStatus, mapper.writeValueAsString(body));
+        } catch (JsonProcessingException e) {
+            // Cannot happen for tree models we built ourselves
+            throw new IllegalStateException(e);
+        }
+    }
+
+    static String decodeSentinel(String headerValue) {
+        if (headerValue == null) {
+            return null;
+        }
+        if (headerValue.startsWith(BASE64_SENTINEL_PREFIX) && headerValue.endsWith(BASE64_SENTINEL_SUFFIX)) {
+            final String encoded = headerValue.substring(BASE64_SENTINEL_PREFIX.length(),
+                    headerValue.length() - BASE64_SENTINEL_SUFFIX.length());
+            try {
+                return new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException e) {
+                return headerValue; // not valid base64: compare verbatim, mismatch will be reported
+            }
+        }
+        return headerValue;
+    }
+
+    private static String lookupBundleVersion() {
+        try {
+            final Bundle bundle = FrameworkUtil.getBundle(McpRequestHandler.class);
+            if (bundle != null) {
+                return bundle.getVersion().toString();
+            }
+        } catch (NoClassDefFoundError | RuntimeException e) {
+            // running outside OSGi (unit tests)
+        }
+        return "dev";
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRestEndpoint.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRestEndpoint.java
@@ -53,8 +53,6 @@ import org.slf4j.LoggerFactory;
 public class McpRestEndpoint {
     private static final Logger LOG = LoggerFactory.getLogger(McpRestEndpoint.class);
 
-    private static final String[] WRITE_ROLES = {"ROLE_ADMIN"};
-
     private final McpRequestHandler handler;
 
     public McpRestEndpoint(McpRequestHandler handler) {
@@ -70,21 +68,13 @@ public class McpRestEndpoint {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
 
-        final McpRequestHandler.Result result = handler.handle(body, request::getHeader, canWrite(request));
+        final McpCaller caller = new McpCaller(request.getRemoteUser(), request::isUserInRole);
+        final McpRequestHandler.Result result = handler.handle(body, request::getHeader, caller);
         final Response.ResponseBuilder builder = Response.status(result.getHttpStatus());
         if (result.getBody() != null) {
             builder.entity(result.getBody()).type(MediaType.APPLICATION_JSON);
         }
         return builder.build();
-    }
-
-    private static boolean canWrite(HttpServletRequest request) {
-        for (String role : WRITE_ROLES) {
-            if (request.isUserInRole(role)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static boolean isSameHost(String origin, String serverName) {

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRestEndpoint.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/McpRestEndpoint.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver;
+
+import java.net.URI;
+import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The MCP endpoint, published through the OSGi JAX-RS connector so it is
+ * served by the same machinery as all other plugin REST endpoints, at
+ * /opennms/rest/mcp behind the regular OpenNMS REST authentication.
+ *
+ * Implements the Streamable HTTP transport of MCP revision 2026-07-28:
+ * a single POST endpoint accepting one JSON-RPC message per request.
+ * GET/DELETE get a 405 from JAX-RS automatically, as the revision requires.
+ */
+@Path("/mcp")
+public class McpRestEndpoint {
+    private static final Logger LOG = LoggerFactory.getLogger(McpRestEndpoint.class);
+
+    private static final String[] WRITE_ROLES = {"ROLE_ADMIN"};
+
+    private final McpRequestHandler handler;
+
+    public McpRestEndpoint(McpRequestHandler handler) {
+        this.handler = Objects.requireNonNull(handler);
+    }
+
+    @POST
+    public Response handle(@Context HttpServletRequest request, String body) {
+        // DNS rebinding protection: browsers set Origin; API clients usually do not.
+        final String origin = request.getHeader("Origin");
+        if (origin != null && !isSameHost(origin, request.getServerName())) {
+            LOG.warn("Rejecting MCP request with foreign Origin header: {}", origin);
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+
+        final McpRequestHandler.Result result = handler.handle(body, request::getHeader, canWrite(request));
+        final Response.ResponseBuilder builder = Response.status(result.getHttpStatus());
+        if (result.getBody() != null) {
+            builder.entity(result.getBody()).type(MediaType.APPLICATION_JSON);
+        }
+        return builder.build();
+    }
+
+    private static boolean canWrite(HttpServletRequest request) {
+        for (String role : WRITE_ROLES) {
+            if (request.isUserInRole(role)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isSameHost(String origin, String serverName) {
+        try {
+            final String originHost = URI.create(origin).getHost();
+            return originHost != null && originHost.equalsIgnoreCase(serverName);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/ToolRegistry.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/ToolRegistry.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Merges the built-in tools with dynamically registered {@link McpToolProvider}
+ * OSGi services. The service list is a live blueprint reference-list, so the
+ * merge happens on every access. Tools are advertised in deterministic
+ * (alphabetical) order as recommended by the MCP specification; on duplicate
+ * names the first registration wins.
+ */
+public class ToolRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger(ToolRegistry.class);
+
+    private final List<McpToolProvider> builtInTools;
+    private final List<McpToolProvider> dynamicTools;
+
+    public ToolRegistry(List<McpToolProvider> builtInTools, List<McpToolProvider> dynamicTools) {
+        this.builtInTools = Objects.requireNonNull(builtInTools);
+        this.dynamicTools = Objects.requireNonNull(dynamicTools);
+    }
+
+    public List<McpToolProvider> getTools() {
+        final Map<String, McpToolProvider> byName = new LinkedHashMap<>();
+        for (McpToolProvider tool : concat()) {
+            final McpToolProvider existing = byName.putIfAbsent(tool.getToolName(), tool);
+            if (existing != null && existing != tool) {
+                LOG.warn("Duplicate MCP tool name '{}' from {}, keeping {}",
+                        tool.getToolName(), tool.getClass().getName(), existing.getClass().getName());
+            }
+        }
+        final List<McpToolProvider> tools = new ArrayList<>(byName.values());
+        tools.sort((a, b) -> a.getToolName().compareTo(b.getToolName()));
+        return Collections.unmodifiableList(tools);
+    }
+
+    public McpToolProvider getTool(String name) {
+        for (McpToolProvider tool : getTools()) {
+            if (tool.getToolName().equals(name)) {
+                return tool;
+            }
+        }
+        return null;
+    }
+
+    private List<McpToolProvider> concat() {
+        final List<McpToolProvider> all = new ArrayList<>(builtInTools);
+        all.addAll(dynamicTools);
+        return all;
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/ToolRegistry.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/ToolRegistry.java
@@ -28,11 +28,10 @@
 package org.opennms.integration.api.mcpserver;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.slf4j.Logger;
@@ -43,7 +42,9 @@ import org.slf4j.LoggerFactory;
  * OSGi services. The service list is a live blueprint reference-list, so the
  * merge happens on every access. Tools are advertised in deterministic
  * (alphabetical) order as recommended by the MCP specification; on duplicate
- * names the first registration wins.
+ * names the first registration wins. Providers that fail to supply a usable
+ * tool name are skipped, so one faulty provider cannot break the registry
+ * for everyone.
  */
 public class ToolRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(ToolRegistry.class);
@@ -57,31 +58,45 @@ public class ToolRegistry {
     }
 
     public List<McpToolProvider> getTools() {
-        final Map<String, McpToolProvider> byName = new LinkedHashMap<>();
-        for (McpToolProvider tool : concat()) {
-            final McpToolProvider existing = byName.putIfAbsent(tool.getToolName(), tool);
-            if (existing != null && existing != tool) {
-                LOG.warn("Duplicate MCP tool name '{}' from {}, keeping {}",
-                        tool.getToolName(), tool.getClass().getName(), existing.getClass().getName());
-            }
-        }
-        final List<McpToolProvider> tools = new ArrayList<>(byName.values());
-        tools.sort((a, b) -> a.getToolName().compareTo(b.getToolName()));
-        return Collections.unmodifiableList(tools);
+        return List.copyOf(toolsByName().values());
     }
 
     public McpToolProvider getTool(String name) {
-        for (McpToolProvider tool : getTools()) {
-            if (tool.getToolName().equals(name)) {
-                return tool;
+        return toolsByName().get(name);
+    }
+
+    private Map<String, McpToolProvider> toolsByName() {
+        final Map<String, McpToolProvider> byName = new TreeMap<>();
+        for (McpToolProvider tool : concat()) {
+            final String name;
+            try {
+                name = tool.getToolName();
+            } catch (RuntimeException e) {
+                LOG.warn("Skipping MCP tool provider {}: getToolName() threw", tool.getClass().getName(), e);
+                continue;
+            }
+            if (name == null || name.isBlank()) {
+                LOG.warn("Skipping MCP tool provider {}: null or blank tool name", tool.getClass().getName());
+                continue;
+            }
+            final McpToolProvider existing = byName.putIfAbsent(name, tool);
+            if (existing != null && existing != tool) {
+                LOG.warn("Duplicate MCP tool name '{}' from {}, keeping {}",
+                        name, tool.getClass().getName(), existing.getClass().getName());
             }
         }
-        return null;
+        return byName;
     }
 
     private List<McpToolProvider> concat() {
         final List<McpToolProvider> all = new ArrayList<>(builtInTools);
-        all.addAll(dynamicTools);
+        try {
+            all.addAll(dynamicTools);
+        } catch (RuntimeException e) {
+            // The dynamic list is a live OSGi proxy; a service vanishing mid-iteration
+            // must not take the built-in tools down with it.
+            LOG.warn("Failed to enumerate dynamically registered MCP tool providers", e);
+        }
         return all;
     }
 }

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 
 import org.opennms.integration.api.v1.dao.InterfaceToNodeCache;
 import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 import org.opennms.integration.api.v1.model.Node;
@@ -73,7 +74,8 @@ public class FindNodeByIpTool implements McpToolProvider {
     }
 
     @Override
-    public McpToolResult execute(Map<String, Object> arguments) {
+    public McpToolResult execute(McpToolContext context) {
+        final Map<String, Object> arguments = context.getArguments();
         final String ip = JsonSupport.stringArgument(arguments, "ip", null);
         if (ip == null) {
             return McpToolResult.error("Missing required argument: ip");

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
@@ -91,13 +91,9 @@ public class FindNodeByIpTool implements McpToolProvider {
         }
 
         final Optional<Integer> nodeId = interfaceToNodeCache.getFirstNodeId(location, inetAddress);
-        if (nodeId.isEmpty()) {
-            return McpToolResult.text("No node found for IP " + ip + " in location " + location);
-        }
-        final Node node = nodeDao.getNodeById(nodeId.get());
+        final Node node = nodeId.map(nodeDao::getNodeById).orElse(null);
         if (node == null) {
-            return McpToolResult.text("Node id " + nodeId.get() + " found for IP " + ip
-                    + " but the node no longer exists");
+            return McpToolResult.text("No node found for IP " + ip + " in location " + location);
         }
         return McpToolResult.text(JsonSupport.toJson(JsonSupport.nodeSummary(node)));
     }

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
@@ -77,8 +77,14 @@ public class FindNodeByIpTool implements McpToolProvider {
     public McpToolResult execute(McpToolContext context) {
         final Map<String, Object> arguments = context.getArguments();
         final String ip = JsonSupport.stringArgument(arguments, "ip", null);
-        if (ip == null) {
+        if (ip == null || ip.isBlank()) {
             return McpToolResult.error("Missing required argument: ip");
+        }
+        // Only accept IP literals: InetAddress.getByName() would resolve host
+        // names via DNS (and an empty string to loopback), letting callers
+        // trigger lookups or match unintended addresses.
+        if (!isIpLiteral(ip)) {
+            return McpToolResult.error("Invalid IP address: " + ip);
         }
         final String location = JsonSupport.stringArgument(arguments, "location",
                 nodeDao.getDefaultLocationName());
@@ -96,5 +102,30 @@ public class FindNodeByIpTool implements McpToolProvider {
             return McpToolResult.text("No node found for IP " + ip + " in location " + location);
         }
         return McpToolResult.text(JsonSupport.toJson(JsonSupport.nodeSummary(node)));
+    }
+
+    /**
+     * True if the string is an IPv4 or IPv6 literal (optionally with an IPv6
+     * zone id). Host names are rejected so no DNS resolution can be triggered.
+     */
+    static boolean isIpLiteral(String value) {
+        final int percent = value.indexOf('%');
+        final String address = percent >= 0 ? value.substring(0, percent) : value;
+        if (address.indexOf(':') >= 0) {
+            // Strings containing ':' are never resolved via DNS; restricting the
+            // character set keeps getByName() to pure IPv6 literal parsing.
+            return address.matches("[0-9a-fA-F:.]+");
+        }
+        final String[] octets = address.split("\\.", -1);
+        if (octets.length != 4) {
+            return false;
+        }
+        for (String octet : octets) {
+            if (octet.isEmpty() || octet.length() > 3 || !octet.chars().allMatch(Character::isDigit)
+                    || Integer.parseInt(octet) > 255) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/FindNodeByIpTool.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.opennms.integration.api.v1.dao.InterfaceToNodeCache;
+import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+import org.opennms.integration.api.v1.model.Node;
+
+public class FindNodeByIpTool implements McpToolProvider {
+    private final InterfaceToNodeCache interfaceToNodeCache;
+    private final NodeDao nodeDao;
+
+    public FindNodeByIpTool(InterfaceToNodeCache interfaceToNodeCache, NodeDao nodeDao) {
+        this.interfaceToNodeCache = Objects.requireNonNull(interfaceToNodeCache);
+        this.nodeDao = Objects.requireNonNull(nodeDao);
+    }
+
+    @Override
+    public String getToolName() {
+        return "find_node_by_ip";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "Find the node that owns a given IP address. Optionally scope the lookup to a "
+                + "monitoring location; defaults to the default location.";
+    }
+
+    @Override
+    public String getInputSchema() {
+        return "{"
+                + "\"type\":\"object\","
+                + "\"properties\":{"
+                + "\"ip\":{\"type\":\"string\",\"description\":\"The IP address to look up\"},"
+                + "\"location\":{\"type\":\"string\",\"description\":\"The monitoring location name\"}"
+                + "},"
+                + "\"required\":[\"ip\"],"
+                + "\"additionalProperties\":false"
+                + "}";
+    }
+
+    @Override
+    public McpToolResult execute(Map<String, Object> arguments) {
+        final String ip = JsonSupport.stringArgument(arguments, "ip", null);
+        if (ip == null) {
+            return McpToolResult.error("Missing required argument: ip");
+        }
+        final String location = JsonSupport.stringArgument(arguments, "location",
+                nodeDao.getDefaultLocationName());
+
+        final InetAddress inetAddress;
+        try {
+            inetAddress = InetAddress.getByName(ip);
+        } catch (UnknownHostException e) {
+            return McpToolResult.error("Invalid IP address: " + ip);
+        }
+
+        final Optional<Integer> nodeId = interfaceToNodeCache.getFirstNodeId(location, inetAddress);
+        if (nodeId.isEmpty()) {
+            return McpToolResult.text("No node found for IP " + ip + " in location " + location);
+        }
+        final Node node = nodeDao.getNodeById(nodeId.get());
+        if (node == null) {
+            return McpToolResult.text("Node id " + nodeId.get() + " found for IP " + ip
+                    + " but the node no longer exists");
+        }
+        return McpToolResult.text(JsonSupport.toJson(JsonSupport.nodeSummary(node)));
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/GetNodeTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/GetNodeTool.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+import org.opennms.integration.api.v1.model.Node;
+
+public class GetNodeTool implements McpToolProvider {
+    private final NodeDao nodeDao;
+
+    public GetNodeTool(NodeDao nodeDao) {
+        this.nodeDao = Objects.requireNonNull(nodeDao);
+    }
+
+    @Override
+    public String getToolName() {
+        return "get_node";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "Get the details of a single node, including its IP interfaces and monitored services. "
+                + "Identify the node either by its database id or by a node criteria string "
+                + "(foreignSource:foreignId).";
+    }
+
+    @Override
+    public String getInputSchema() {
+        return "{"
+                + "\"type\":\"object\","
+                + "\"properties\":{"
+                + "\"id\":{\"type\":\"integer\",\"description\":\"The node database id\"},"
+                + "\"criteria\":{\"type\":\"string\",\"description\":\"Node criteria, e.g. 'my-requisition:node-123'\"}"
+                + "},"
+                + "\"additionalProperties\":false"
+                + "}";
+    }
+
+    @Override
+    public McpToolResult execute(Map<String, Object> arguments) {
+        final Node node;
+        if (arguments.get("id") != null) {
+            node = nodeDao.getNodeById(JsonSupport.intArgument(arguments, "id", -1));
+        } else if (arguments.get("criteria") != null) {
+            node = nodeDao.getNodeByCriteria(JsonSupport.stringArgument(arguments, "criteria", null));
+        } else {
+            return McpToolResult.error("Either 'id' or 'criteria' must be provided");
+        }
+
+        if (node == null) {
+            return McpToolResult.error("No such node");
+        }
+        return McpToolResult.text(JsonSupport.toJson(JsonSupport.nodeDetail(node)));
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/GetNodeTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/GetNodeTool.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 import org.opennms.integration.api.v1.model.Node;
@@ -67,7 +68,8 @@ public class GetNodeTool implements McpToolProvider {
     }
 
     @Override
-    public McpToolResult execute(Map<String, Object> arguments) {
+    public McpToolResult execute(McpToolContext context) {
+        final Map<String, Object> arguments = context.getArguments();
         final Node node;
         if (arguments.get("id") != null) {
             node = nodeDao.getNodeById(JsonSupport.intArgument(arguments, "id", -1));

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/JsonSupport.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/JsonSupport.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.model.Alarm;
+import org.opennms.integration.api.v1.model.IpInterface;
+import org.opennms.integration.api.v1.model.Node;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * JSON mapping helpers shared by the built-in tools. OIA model objects are
+ * mapped to plain maps explicitly so the JSON stays stable and small.
+ */
+final class JsonSupport {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonSupport() {
+    }
+
+    static String toJson(Object value) {
+        try {
+            return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize tool result", e);
+        }
+    }
+
+    static Map<String, Object> nodeSummary(Node node) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put("id", node.getId());
+        map.put("label", node.getLabel());
+        map.put("location", node.getLocation());
+        map.put("foreignSource", node.getForeignSource());
+        map.put("foreignId", node.getForeignId());
+        map.put("categories", node.getCategories());
+        return map;
+    }
+
+    static Map<String, Object> nodeDetail(Node node) {
+        final Map<String, Object> map = nodeSummary(node);
+        final List<Map<String, Object>> interfaces = new ArrayList<>();
+        for (IpInterface ipInterface : node.getIpInterfaces()) {
+            final Map<String, Object> ifaceMap = new LinkedHashMap<>();
+            ifaceMap.put("ipAddress", ipInterface.getIpAddress() != null
+                    ? ipInterface.getIpAddress().getHostAddress() : null);
+            ifaceMap.put("services", ipInterface.getMonitoredServices().stream()
+                    .map(s -> s.getName())
+                    .collect(Collectors.toList()));
+            interfaces.add(ifaceMap);
+        }
+        map.put("ipInterfaces", interfaces);
+        map.put("snmpInterfaceCount", node.getSnmpInterfaces().size());
+        return map;
+    }
+
+    static Map<String, Object> alarmSummary(Alarm alarm) {
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put("id", alarm.getId());
+        map.put("reductionKey", alarm.getReductionKey());
+        map.put("severity", alarm.getSeverity() != null ? alarm.getSeverity().name() : null);
+        map.put("logMessage", alarm.getLogMessage());
+        map.put("nodeId", alarm.getNode() != null ? alarm.getNode().getId() : null);
+        map.put("nodeLabel", alarm.getNode() != null ? alarm.getNode().getLabel() : null);
+        map.put("firstEventTime", formatDate(alarm.getFirstEventTime()));
+        map.put("lastEventTime", formatDate(alarm.getLastEventTime()));
+        map.put("acknowledged", alarm.isAcknowledged());
+        map.put("situation", alarm.isSituation());
+        map.put("ticketId", alarm.getTicketId());
+        return map;
+    }
+
+    private static String formatDate(Date date) {
+        return date != null ? date.toInstant().toString() : null;
+    }
+
+    static int intArgument(Map<String, Object> arguments, String name, int defaultValue) {
+        final Object value = arguments.get(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        return exactInt(value, name);
+    }
+
+    /**
+     * Converts a parsed JSON number to an int, rejecting fractional values and
+     * values outside the int range instead of silently truncating or wrapping
+     * them onto a different (and possibly existing) identifier.
+     */
+    static int exactInt(Object value, String name) {
+        if (value instanceof Integer) {
+            return (Integer) value;
+        }
+        if (value instanceof Long) {
+            final long l = (Long) value;
+            if (l != (int) l) {
+                throw new IllegalArgumentException("Argument '" + name + "' is out of integer range: " + l);
+            }
+            return (int) l;
+        }
+        if (value instanceof Double || value instanceof Float) {
+            final double d = ((Number) value).doubleValue();
+            final int i = (int) d;
+            if (d != i) {
+                throw new IllegalArgumentException("Argument '" + name + "' must be an exact integer: " + d);
+            }
+            return i;
+        }
+        if (value instanceof java.math.BigInteger || value instanceof java.math.BigDecimal) {
+            try {
+                return value instanceof java.math.BigInteger
+                        ? ((java.math.BigInteger) value).intValueExact()
+                        : ((java.math.BigDecimal) value).intValueExact();
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException("Argument '" + name + "' must be an exact integer: " + value);
+            }
+        }
+        throw new IllegalArgumentException("Argument '" + name + "' must be an integer");
+    }
+
+    static String stringArgument(Map<String, Object> arguments, String name, String defaultValue) {
+        final Object value = arguments.get(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof String) {
+            return (String) value;
+        }
+        throw new IllegalArgumentException("Argument '" + name + "' must be a string");
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListAlarmsTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListAlarmsTool.java
@@ -56,7 +56,7 @@ public class ListAlarmsTool implements McpToolProvider {
     public String getToolDescription() {
         return "List current alarms, most severe first. Optionally filter by minimum severity "
                 + "(INDETERMINATE, CLEARED, NORMAL, WARNING, MINOR, MAJOR, CRITICAL) and by "
-                + "acknowledgement state.";
+                + "acknowledgement state. Returns at most 1000 alarms per call.";
     }
 
     @Override
@@ -67,7 +67,8 @@ public class ListAlarmsTool implements McpToolProvider {
                 + "\"minSeverity\":{\"type\":\"string\",\"description\":\"Only return alarms at or above this severity\","
                 + "\"enum\":[\"INDETERMINATE\",\"CLEARED\",\"NORMAL\",\"WARNING\",\"MINOR\",\"MAJOR\",\"CRITICAL\"]},"
                 + "\"acknowledged\":{\"type\":\"boolean\",\"description\":\"Only return alarms with this acknowledgement state\"},"
-                + "\"limit\":{\"type\":\"integer\",\"description\":\"Maximum number of alarms to return\",\"default\":100}"
+                + "\"limit\":{\"type\":\"integer\",\"description\":\"Maximum number of alarms to return\","
+                + "\"minimum\":1,\"maximum\":1000,\"default\":100}"
                 + "},"
                 + "\"additionalProperties\":false"
                 + "}";

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListAlarmsTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListAlarmsTool.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.opennms.integration.api.v1.dao.AlarmDao;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 import org.opennms.integration.api.v1.model.Alarm;
@@ -73,7 +74,8 @@ public class ListAlarmsTool implements McpToolProvider {
     }
 
     @Override
-    public McpToolResult execute(Map<String, Object> arguments) {
+    public McpToolResult execute(McpToolContext context) {
+        final Map<String, Object> arguments = context.getArguments();
         final int limit = Math.max(1, Math.min(1000, JsonSupport.intArgument(arguments, "limit", 100)));
         final String minSeverityArg = JsonSupport.stringArgument(arguments, "minSeverity", null);
         final Object acknowledgedArg = arguments.get("acknowledged");

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListAlarmsTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListAlarmsTool.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.dao.AlarmDao;
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+import org.opennms.integration.api.v1.model.Alarm;
+import org.opennms.integration.api.v1.model.Severity;
+
+public class ListAlarmsTool implements McpToolProvider {
+    private final AlarmDao alarmDao;
+
+    public ListAlarmsTool(AlarmDao alarmDao) {
+        this.alarmDao = Objects.requireNonNull(alarmDao);
+    }
+
+    @Override
+    public String getToolName() {
+        return "list_alarms";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "List current alarms, most severe first. Optionally filter by minimum severity "
+                + "(INDETERMINATE, CLEARED, NORMAL, WARNING, MINOR, MAJOR, CRITICAL) and by "
+                + "acknowledgement state.";
+    }
+
+    @Override
+    public String getInputSchema() {
+        return "{"
+                + "\"type\":\"object\","
+                + "\"properties\":{"
+                + "\"minSeverity\":{\"type\":\"string\",\"description\":\"Only return alarms at or above this severity\","
+                + "\"enum\":[\"INDETERMINATE\",\"CLEARED\",\"NORMAL\",\"WARNING\",\"MINOR\",\"MAJOR\",\"CRITICAL\"]},"
+                + "\"acknowledged\":{\"type\":\"boolean\",\"description\":\"Only return alarms with this acknowledgement state\"},"
+                + "\"limit\":{\"type\":\"integer\",\"description\":\"Maximum number of alarms to return\",\"default\":100}"
+                + "},"
+                + "\"additionalProperties\":false"
+                + "}";
+    }
+
+    @Override
+    public McpToolResult execute(Map<String, Object> arguments) {
+        final int limit = Math.max(1, Math.min(1000, JsonSupport.intArgument(arguments, "limit", 100)));
+        final String minSeverityArg = JsonSupport.stringArgument(arguments, "minSeverity", null);
+        final Object acknowledgedArg = arguments.get("acknowledged");
+
+        final Severity minSeverity;
+        try {
+            minSeverity = minSeverityArg != null ? Severity.valueOf(minSeverityArg.toUpperCase()) : null;
+        } catch (IllegalArgumentException e) {
+            return McpToolResult.error("Unknown severity: " + minSeverityArg);
+        }
+
+        List<Alarm> alarms = alarmDao.getAlarms();
+        if (minSeverity != null) {
+            alarms = alarms.stream()
+                    .filter(a -> a.getSeverity() != null && a.getSeverity().compareTo(minSeverity) >= 0)
+                    .collect(Collectors.toList());
+        }
+        if (acknowledgedArg instanceof Boolean) {
+            final boolean acknowledged = (Boolean) acknowledgedArg;
+            alarms = alarms.stream()
+                    .filter(a -> a.isAcknowledged() == acknowledged)
+                    .collect(Collectors.toList());
+        }
+
+        final int total = alarms.size();
+        final List<Map<String, Object>> results = alarms.stream()
+                .sorted(Comparator.comparing(Alarm::getSeverity,
+                        Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(limit)
+                .map(JsonSupport::alarmSummary)
+                .collect(Collectors.toList());
+
+        return McpToolResult.text(JsonSupport.toJson(Map.of(
+                "totalMatches", total,
+                "returned", results.size(),
+                "alarms", results)));
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListNodesTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListNodesTool.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 import org.opennms.integration.api.v1.model.Node;
@@ -69,7 +70,8 @@ public class ListNodesTool implements McpToolProvider {
     }
 
     @Override
-    public McpToolResult execute(Map<String, Object> arguments) {
+    public McpToolResult execute(McpToolContext context) {
+        final Map<String, Object> arguments = context.getArguments();
         final int limit = Math.max(1, Math.min(500, JsonSupport.intArgument(arguments, "limit", 50)));
         final String search = JsonSupport.stringArgument(arguments, "search", null);
 

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListNodesTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListNodesTool.java
@@ -54,7 +54,7 @@ public class ListNodesTool implements McpToolProvider {
     @Override
     public String getToolDescription() {
         return "List the nodes in the OpenNMS inventory. Optionally filter by a case-insensitive "
-                + "substring of the node label and limit the number of results.";
+                + "substring of the node label and limit the number of results (at most 500 per call).";
     }
 
     @Override
@@ -63,7 +63,8 @@ public class ListNodesTool implements McpToolProvider {
                 + "\"type\":\"object\","
                 + "\"properties\":{"
                 + "\"search\":{\"type\":\"string\",\"description\":\"Case-insensitive substring to match against node labels\"},"
-                + "\"limit\":{\"type\":\"integer\",\"description\":\"Maximum number of nodes to return\",\"default\":50}"
+                + "\"limit\":{\"type\":\"integer\",\"description\":\"Maximum number of nodes to return\","
+                + "\"minimum\":1,\"maximum\":500,\"default\":50}"
                 + "},"
                 + "\"additionalProperties\":false"
                 + "}";

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListNodesTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/ListNodesTool.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.opennms.integration.api.v1.dao.NodeDao;
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+import org.opennms.integration.api.v1.model.Node;
+
+public class ListNodesTool implements McpToolProvider {
+    private final NodeDao nodeDao;
+
+    public ListNodesTool(NodeDao nodeDao) {
+        this.nodeDao = Objects.requireNonNull(nodeDao);
+    }
+
+    @Override
+    public String getToolName() {
+        return "list_nodes";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "List the nodes in the OpenNMS inventory. Optionally filter by a case-insensitive "
+                + "substring of the node label and limit the number of results.";
+    }
+
+    @Override
+    public String getInputSchema() {
+        return "{"
+                + "\"type\":\"object\","
+                + "\"properties\":{"
+                + "\"search\":{\"type\":\"string\",\"description\":\"Case-insensitive substring to match against node labels\"},"
+                + "\"limit\":{\"type\":\"integer\",\"description\":\"Maximum number of nodes to return\",\"default\":50}"
+                + "},"
+                + "\"additionalProperties\":false"
+                + "}";
+    }
+
+    @Override
+    public McpToolResult execute(Map<String, Object> arguments) {
+        final int limit = Math.max(1, Math.min(500, JsonSupport.intArgument(arguments, "limit", 50)));
+        final String search = JsonSupport.stringArgument(arguments, "search", null);
+
+        List<Node> nodes = nodeDao.getNodes();
+        if (search != null && !search.isBlank()) {
+            final String needle = search.toLowerCase(Locale.ROOT);
+            nodes = nodes.stream()
+                    .filter(n -> n.getLabel() != null && n.getLabel().toLowerCase(Locale.ROOT).contains(needle))
+                    .collect(Collectors.toList());
+        }
+
+        final int total = nodes.size();
+        final List<Map<String, Object>> results = nodes.stream()
+                .limit(limit)
+                .map(JsonSupport::nodeSummary)
+                .collect(Collectors.toList());
+
+        return McpToolResult.text(JsonSupport.toJson(Map.of(
+                "totalMatches", total,
+                "returned", results.size(),
+                "nodes", results)));
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/SendEventTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/SendEventTool.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.events.EventForwarder;
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+import org.opennms.integration.api.v1.model.Severity;
+import org.opennms.integration.api.v1.model.immutables.ImmutableEventParameter;
+import org.opennms.integration.api.v1.model.immutables.ImmutableInMemoryEvent;
+
+public class SendEventTool implements McpToolProvider {
+    private final EventForwarder eventForwarder;
+
+    public SendEventTool(EventForwarder eventForwarder) {
+        this.eventForwarder = Objects.requireNonNull(eventForwarder);
+    }
+
+    @Override
+    public String getToolName() {
+        return "send_event";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "Send an event into the OpenNMS event bus. The event is identified by its UEI "
+                + "(unique event identifier) and may carry a node id, severity and parameters.";
+    }
+
+    @Override
+    public String getInputSchema() {
+        return "{"
+                + "\"type\":\"object\","
+                + "\"properties\":{"
+                + "\"uei\":{\"type\":\"string\",\"description\":\"The unique event identifier, e.g. 'uei.opennms.org/custom/myEvent'\"},"
+                + "\"nodeId\":{\"type\":\"integer\",\"description\":\"The node this event relates to\"},"
+                + "\"severity\":{\"type\":\"string\",\"enum\":[\"INDETERMINATE\",\"CLEARED\",\"NORMAL\",\"WARNING\",\"MINOR\",\"MAJOR\",\"CRITICAL\"]},"
+                + "\"parameters\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"},"
+                + "\"description\":\"Event parameters as name/value pairs\"}"
+                + "},"
+                + "\"required\":[\"uei\"],"
+                + "\"additionalProperties\":false"
+                + "}";
+    }
+
+    @Override
+    public boolean isWriteAccess() {
+        return true;
+    }
+
+    @Override
+    public McpToolResult execute(Map<String, Object> arguments) {
+        final String uei = JsonSupport.stringArgument(arguments, "uei", null);
+        if (uei == null || uei.isBlank()) {
+            return McpToolResult.error("Missing required argument: uei");
+        }
+
+        final ImmutableInMemoryEvent.Builder builder = ImmutableInMemoryEvent.newBuilder()
+                .setUei(uei)
+                .setSource("mcp");
+
+        if (arguments.get("nodeId") != null) {
+            builder.setNodeId(JsonSupport.intArgument(arguments, "nodeId", -1));
+        }
+        final String severity = JsonSupport.stringArgument(arguments, "severity", null);
+        if (severity != null) {
+            try {
+                builder.setSeverity(Severity.valueOf(severity.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                return McpToolResult.error("Unknown severity: " + severity);
+            }
+        }
+        final Object parameters = arguments.get("parameters");
+        if (parameters instanceof Map) {
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) parameters).entrySet()) {
+                builder.addParameter(ImmutableEventParameter.newBuilder()
+                        .setName(String.valueOf(entry.getKey()))
+                        .setValue(String.valueOf(entry.getValue()))
+                        .build());
+            }
+        }
+
+        eventForwarder.sendAsync(builder.build());
+        return McpToolResult.text("Event " + uei + " sent");
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/SendEventTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/SendEventTool.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.opennms.integration.api.v1.events.EventForwarder;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 import org.opennms.integration.api.v1.model.Severity;
@@ -77,15 +78,19 @@ public class SendEventTool implements McpToolProvider {
     }
 
     @Override
-    public McpToolResult execute(Map<String, Object> arguments) {
+    public McpToolResult execute(McpToolContext context) {
+        final Map<String, Object> arguments = context.getArguments();
         final String uei = JsonSupport.stringArgument(arguments, "uei", null);
         if (uei == null || uei.isBlank()) {
             return McpToolResult.error("Missing required argument: uei");
         }
 
+        // Record who sent the event: the authenticated principal, not a value
+        // the model could choose.
+        final String source = "mcp:" + (context.getUserName() != null ? context.getUserName() : "anonymous");
         final ImmutableInMemoryEvent.Builder builder = ImmutableInMemoryEvent.newBuilder()
                 .setUei(uei)
-                .setSource("mcp");
+                .setSource(source);
 
         if (arguments.get("nodeId") != null) {
             builder.setNodeId(JsonSupport.intArgument(arguments, "nodeId", -1));

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/UpdateAlarmsTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/UpdateAlarmsTool.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opennms.integration.api.v1.dao.AlarmDao;
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+
+public class UpdateAlarmsTool implements McpToolProvider {
+    private final AlarmDao alarmDao;
+
+    public UpdateAlarmsTool(AlarmDao alarmDao) {
+        this.alarmDao = Objects.requireNonNull(alarmDao);
+    }
+
+    @Override
+    public String getToolName() {
+        return "update_alarms";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "Acknowledge, unacknowledge, escalate or clear one or more alarms by id.";
+    }
+
+    @Override
+    public String getInputSchema() {
+        return "{"
+                + "\"type\":\"object\","
+                + "\"properties\":{"
+                + "\"alarmIds\":{\"type\":\"array\",\"items\":{\"type\":\"integer\"},\"minItems\":1,"
+                + "\"description\":\"The ids of the alarms to update\"},"
+                + "\"action\":{\"type\":\"string\",\"enum\":[\"acknowledge\",\"unacknowledge\",\"escalate\",\"clear\"],"
+                + "\"description\":\"The action to apply\"},"
+                + "\"user\":{\"type\":\"string\",\"description\":\"The user to record for acknowledge/escalate\",\"default\":\"mcp\"}"
+                + "},"
+                + "\"required\":[\"alarmIds\",\"action\"],"
+                + "\"additionalProperties\":false"
+                + "}";
+    }
+
+    @Override
+    public boolean isWriteAccess() {
+        return true;
+    }
+
+    @Override
+    public McpToolResult execute(Map<String, Object> arguments) {
+        final Object alarmIdsArg = arguments.get("alarmIds");
+        if (!(alarmIdsArg instanceof List) || ((List<?>) alarmIdsArg).isEmpty()) {
+            return McpToolResult.error("Argument 'alarmIds' must be a non-empty array of integers");
+        }
+        final int[] alarmIds;
+        try {
+            alarmIds = ((List<?>) alarmIdsArg).stream()
+                    .mapToInt(v -> JsonSupport.exactInt(v, "alarmIds"))
+                    .toArray();
+        } catch (IllegalArgumentException e) {
+            return McpToolResult.error(e.getMessage());
+        }
+
+        final String action = JsonSupport.stringArgument(arguments, "action", "");
+        final String user = JsonSupport.stringArgument(arguments, "user", "mcp");
+
+        switch (action.toLowerCase(Locale.ROOT)) {
+            case "acknowledge":
+                alarmDao.acknowledge(user, alarmIds);
+                break;
+            case "unacknowledge":
+                alarmDao.unacknowledge(alarmIds);
+                break;
+            case "escalate":
+                alarmDao.escalate(user, alarmIds);
+                break;
+            case "clear":
+                alarmDao.clear(alarmIds);
+                break;
+            default:
+                return McpToolResult.error("Unknown action: " + action);
+        }
+        return McpToolResult.text("Applied '" + action + "' to " + alarmIds.length + " alarm(s)");
+    }
+}

--- a/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/UpdateAlarmsTool.java
+++ b/mcp-server/src/main/java/org/opennms/integration/api/mcpserver/tools/UpdateAlarmsTool.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.opennms.integration.api.v1.dao.AlarmDao;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 
@@ -61,8 +62,7 @@ public class UpdateAlarmsTool implements McpToolProvider {
                 + "\"alarmIds\":{\"type\":\"array\",\"items\":{\"type\":\"integer\"},\"minItems\":1,"
                 + "\"description\":\"The ids of the alarms to update\"},"
                 + "\"action\":{\"type\":\"string\",\"enum\":[\"acknowledge\",\"unacknowledge\",\"escalate\",\"clear\"],"
-                + "\"description\":\"The action to apply\"},"
-                + "\"user\":{\"type\":\"string\",\"description\":\"The user to record for acknowledge/escalate\",\"default\":\"mcp\"}"
+                + "\"description\":\"The action to apply\"}"
                 + "},"
                 + "\"required\":[\"alarmIds\",\"action\"],"
                 + "\"additionalProperties\":false"
@@ -75,7 +75,8 @@ public class UpdateAlarmsTool implements McpToolProvider {
     }
 
     @Override
-    public McpToolResult execute(Map<String, Object> arguments) {
+    public McpToolResult execute(McpToolContext context) {
+        final Map<String, Object> arguments = context.getArguments();
         final Object alarmIdsArg = arguments.get("alarmIds");
         if (!(alarmIdsArg instanceof List) || ((List<?>) alarmIdsArg).isEmpty()) {
             return McpToolResult.error("Argument 'alarmIds' must be a non-empty array of integers");
@@ -90,7 +91,9 @@ public class UpdateAlarmsTool implements McpToolProvider {
         }
 
         final String action = JsonSupport.stringArgument(arguments, "action", "");
-        final String user = JsonSupport.stringArgument(arguments, "user", "mcp");
+        // The audit identity is the authenticated principal, never a tool argument
+        // the model could choose.
+        final String user = context.getUserName() != null ? context.getUserName() : "mcp";
 
         switch (action.toLowerCase(Locale.ROOT)) {
             case "acknowledge":

--- a/mcp-server/src/main/resources/OSGI-INF/blueprint/blueprint-mcp-server.xml
+++ b/mcp-server/src/main/resources/OSGI-INF/blueprint/blueprint-mcp-server.xml
@@ -1,0 +1,67 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+        http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <reference id="nodeDao" interface="org.opennms.integration.api.v1.dao.NodeDao" />
+    <reference id="alarmDao" interface="org.opennms.integration.api.v1.dao.AlarmDao" />
+    <reference id="interfaceToNodeCache" interface="org.opennms.integration.api.v1.dao.InterfaceToNodeCache" />
+    <reference id="eventForwarder" interface="org.opennms.integration.api.v1.events.EventForwarder" />
+
+    <!-- Built-in tools -->
+    <bean id="listNodesTool" class="org.opennms.integration.api.mcpserver.tools.ListNodesTool">
+        <argument ref="nodeDao"/>
+    </bean>
+    <bean id="getNodeTool" class="org.opennms.integration.api.mcpserver.tools.GetNodeTool">
+        <argument ref="nodeDao"/>
+    </bean>
+    <bean id="listAlarmsTool" class="org.opennms.integration.api.mcpserver.tools.ListAlarmsTool">
+        <argument ref="alarmDao"/>
+    </bean>
+    <bean id="findNodeByIpTool" class="org.opennms.integration.api.mcpserver.tools.FindNodeByIpTool">
+        <argument ref="interfaceToNodeCache"/>
+        <argument ref="nodeDao"/>
+    </bean>
+    <bean id="updateAlarmsTool" class="org.opennms.integration.api.mcpserver.tools.UpdateAlarmsTool">
+        <argument ref="alarmDao"/>
+    </bean>
+    <bean id="sendEventTool" class="org.opennms.integration.api.mcpserver.tools.SendEventTool">
+        <argument ref="eventForwarder"/>
+    </bean>
+
+    <!-- Tools contributed by other plugins via the Integration API -->
+    <reference-list id="toolProviders" interface="org.opennms.integration.api.v1.mcp.McpToolProvider"
+                    availability="optional"/>
+
+    <bean id="toolRegistry" class="org.opennms.integration.api.mcpserver.ToolRegistry">
+        <argument>
+            <list>
+                <ref component-id="listNodesTool"/>
+                <ref component-id="getNodeTool"/>
+                <ref component-id="listAlarmsTool"/>
+                <ref component-id="findNodeByIpTool"/>
+                <ref component-id="updateAlarmsTool"/>
+                <ref component-id="sendEventTool"/>
+            </list>
+        </argument>
+        <argument ref="toolProviders"/>
+    </bean>
+
+    <bean id="mcpRequestHandler" class="org.opennms.integration.api.mcpserver.McpRequestHandler">
+        <argument ref="toolRegistry"/>
+    </bean>
+
+    <!-- Published through the OSGi JAX-RS connector, mounted under /rest via
+         application-path (like the other OSGi REST services), surfacing at
+         /opennms/rest/mcp. Living under /rest/** puts it in the stateless
+         basic-auth Spring Security block (CSRF disabled, POST requires
+         ROLE_REST/ROLE_ADMIN); other paths get the interactive web-UI
+         security (login redirects, CSRF). -->
+    <service interface="org.opennms.integration.api.mcpserver.McpRestEndpoint">
+        <service-properties>
+            <entry key="application-path" value="/rest" />
+        </service-properties>
+        <bean class="org.opennms.integration.api.mcpserver.McpRestEndpoint">
+            <argument ref="mcpRequestHandler"/>
+        </bean>
+    </service>
+</blueprint>

--- a/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/McpRequestHandlerTest.java
+++ b/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/McpRequestHandlerTest.java
@@ -197,12 +197,58 @@ public class McpRequestHandlerTest {
         }
     }
 
+    private static class ThrowingNameTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            throw new IllegalStateException("gone");
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "never reached";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return "{\"type\":\"object\"}";
+        }
+
+        @Override
+        public McpToolResult execute(McpToolContext context) {
+            return McpToolResult.text("never reached");
+        }
+    }
+
+    private static class NullNameTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            return null;
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "never reached";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return "{\"type\":\"object\"}";
+        }
+
+        @Override
+        public McpToolResult execute(McpToolContext context) {
+            return McpToolResult.text("never reached");
+        }
+    }
+
     @Before
     public void setUp() {
+        // ThrowingNameTool and NullNameTool are registered as dynamic providers:
+        // faulty providers must not break the registry for everyone else.
         handler = new McpRequestHandler(new ToolRegistry(
                 List.of(new EchoTool(), new RestrictedTool(), new BrokenTool(),
                         new NullSchemaTool(), new NullResultTool(), new HeaderParamTool()),
-                List.of()));
+                List.of(new ThrowingNameTool(), new NullNameTool())));
     }
 
     private static McpCaller caller(String... roles) {
@@ -362,13 +408,18 @@ public class McpRequestHandlerTest {
     }
 
     @Test
-    public void toolExceptionsBecomeErrorResults() throws Exception {
+    public void toolExceptionsBecomeGenericErrorResults() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 request(4, "tools/call", Map.of("name", "broken")),
                 headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "broken"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
-        assertThat(body(result).path("result").path("isError").asBoolean(), is(true));
+        final JsonNode callResult = body(result).path("result");
+        assertThat(callResult.path("isError").asBoolean(), is(true));
+        // The exception message ("boom") must stay in the server log, not the response
+        final String text = callResult.path("content").get(0).path("text").asText();
+        assertThat(text.contains("boom"), is(false));
+        assertThat(text, equalTo("Tool execution failed; see the server log for details"));
     }
 
     @Test

--- a/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/McpRequestHandlerTest.java
+++ b/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/McpRequestHandlerTest.java
@@ -37,11 +37,13 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolProvider;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 
@@ -54,6 +56,7 @@ public class McpRequestHandlerTest {
     private final ObjectMapper mapper = new ObjectMapper();
     private McpRequestHandler handler;
     private Map<String, Object> lastEchoArguments;
+    private String lastEchoUser;
 
     private class EchoTool implements McpToolProvider {
         @Override
@@ -72,9 +75,10 @@ public class McpRequestHandlerTest {
         }
 
         @Override
-        public McpToolResult execute(Map<String, Object> arguments) {
-            lastEchoArguments = arguments;
-            return McpToolResult.text("echo: " + arguments.get("message"));
+        public McpToolResult execute(McpToolContext context) {
+            lastEchoArguments = context.getArguments();
+            lastEchoUser = context.getUserName();
+            return McpToolResult.text("echo: " + context.getArguments().get("message"));
         }
     }
 
@@ -100,7 +104,7 @@ public class McpRequestHandlerTest {
         }
 
         @Override
-        public McpToolResult execute(Map<String, Object> arguments) {
+        public McpToolResult execute(McpToolContext context) {
             return McpToolResult.text("done");
         }
     }
@@ -113,7 +117,7 @@ public class McpRequestHandlerTest {
 
         @Override
         public String getToolDescription() {
-            return "Always throws";
+            return "Always throws, schema is not JSON";
         }
 
         @Override
@@ -122,15 +126,96 @@ public class McpRequestHandlerTest {
         }
 
         @Override
-        public McpToolResult execute(Map<String, Object> arguments) {
+        public McpToolResult execute(McpToolContext context) {
             throw new IllegalStateException("boom");
+        }
+    }
+
+    private static class NullSchemaTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            return "null-schema";
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "Returns a null schema";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return null;
+        }
+
+        @Override
+        public McpToolResult execute(McpToolContext context) {
+            return McpToolResult.text("never reached");
+        }
+    }
+
+    private static class NullResultTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            return "null-result";
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "Returns null from execute";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return "{\"type\":\"object\"}";
+        }
+
+        @Override
+        public McpToolResult execute(McpToolContext context) {
+            return null;
+        }
+    }
+
+    private static class HeaderParamTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            return "header-param";
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "Declares x-mcp-header, which this server does not support";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return "{\"type\":\"object\",\"properties\":{\"region\":{\"type\":\"string\",\"x-mcp-header\":\"Region\"}}}";
+        }
+
+        @Override
+        public McpToolResult execute(McpToolContext context) {
+            return McpToolResult.text("never reached");
         }
     }
 
     @Before
     public void setUp() {
         handler = new McpRequestHandler(new ToolRegistry(
-                List.of(new EchoTool(), new RestrictedTool(), new BrokenTool()), List.of()));
+                List.of(new EchoTool(), new RestrictedTool(), new BrokenTool(),
+                        new NullSchemaTool(), new NullResultTool(), new HeaderParamTool()),
+                List.of()));
+    }
+
+    private static McpCaller caller(String... roles) {
+        final Set<String> roleSet = Set.of(roles);
+        return new McpCaller("test-user", roleSet::contains);
+    }
+
+    private static McpCaller reader() {
+        return caller("ROLE_REST");
+    }
+
+    private static McpCaller admin() {
+        return caller("ROLE_REST", "ROLE_ADMIN");
     }
 
     private static Function<String, String> headers(String... namesAndValues) {
@@ -168,7 +253,7 @@ public class McpRequestHandlerTest {
     @Test
     public void canDiscover() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
-                request(1, "server/discover", Map.of()), standardHeaders("server/discover"), false);
+                request(1, "server/discover", Map.of()), standardHeaders("server/discover"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
         final JsonNode response = body(result);
@@ -187,7 +272,7 @@ public class McpRequestHandlerTest {
         final String body = request(1, "server/discover", Map.of())
                 .replace(PV, "1999-01-01");
         final McpRequestHandler.Result result = handler.handle(body,
-                headers("MCP-Protocol-Version", "1999-01-01", "Mcp-Method", "server/discover"), false);
+                headers("MCP-Protocol-Version", "1999-01-01", "Mcp-Method", "server/discover"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
         assertThat(body(result).path("result").path("supportedVersions").get(0).asText(), equalTo(PV));
@@ -196,7 +281,7 @@ public class McpRequestHandlerTest {
     @Test
     public void canListTools() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
-                request(2, "tools/list", Map.of()), standardHeaders("tools/list"), false);
+                request(2, "tools/list", Map.of()), standardHeaders("tools/list"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
         final JsonNode listResult = body(result).path("result");
@@ -204,41 +289,48 @@ public class McpRequestHandlerTest {
         assertThat(listResult.path("cacheScope").asText(), equalTo("private"));
         assertThat(listResult.path("ttlMs").isNumber(), is(true));
 
+        // deterministic (alphabetical) order; write tools hidden from read-only users;
+        // null-schema and x-mcp-header tools are not served
         final JsonNode tools = listResult.path("tools");
-        // deterministic (alphabetical) order; write tools are hidden from read-only users
-        assertThat(tools.size(), equalTo(2));
+        assertThat(tools.size(), equalTo(3));
         assertThat(tools.get(0).path("name").asText(), equalTo("broken"));
         assertThat(tools.get(1).path("name").asText(), equalTo("echo"));
+        assertThat(tools.get(2).path("name").asText(), equalTo("null-result"));
         assertThat(tools.get(1).path("inputSchema").path("type").asText(), equalTo("object"));
-        // invalid schema string falls back to an open object schema
+        // invalid (but present) schema string falls back to an open object schema
         assertThat(tools.get(0).path("inputSchema").path("type").asText(), equalTo("object"));
     }
 
     @Test
     public void writeToolsAreListedForAdmins() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
-                request(2, "tools/list", Map.of()), standardHeaders("tools/list"), true);
+                request(2, "tools/list", Map.of()), standardHeaders("tools/list"), admin());
 
         final JsonNode tools = body(result).path("result").path("tools");
-        assertThat(tools.size(), equalTo(3));
-        assertThat(tools.get(2).path("name").asText(), equalTo("restricted"));
+        assertThat(tools.size(), equalTo(4));
+        assertThat(tools.get(3).path("name").asText(), equalTo("restricted"));
     }
 
     @Test
-    public void explicitNullIdIsInvalidRequest() throws Exception {
-        final McpRequestHandler.Result result = handler.handle(
-                "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"tools/list\"}",
-                standardHeaders("tools/list"), false);
+    public void readonlyAdminIsTreatedAsReader() throws Exception {
+        final McpCaller readonlyAdmin = caller("ROLE_REST", "ROLE_ADMIN", "ROLE_READONLY");
 
-        assertThat(result.getHttpStatus(), equalTo(400));
-        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32600));
+        final McpRequestHandler.Result list = handler.handle(
+                request(2, "tools/list", Map.of()), standardHeaders("tools/list"), readonlyAdmin);
+        assertThat(body(list).path("result").path("tools").size(), equalTo(3));
+
+        final McpRequestHandler.Result call = handler.handle(
+                request(3, "tools/call", Map.of("name", "restricted")),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "restricted"),
+                readonlyAdmin);
+        assertThat(body(call).path("error").path("code").asInt(), equalTo(-32000));
     }
 
     @Test
     public void canCallTool() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 request(3, "tools/call", Map.of("name", "echo", "arguments", Map.of("message", "hi"))),
-                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "echo"), false);
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "echo"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
         final JsonNode callResult = body(result).path("result");
@@ -250,11 +342,20 @@ public class McpRequestHandlerTest {
     }
 
     @Test
+    public void toolSeesTheAuthenticatedUser() throws Exception {
+        handler.handle(
+                request(3, "tools/call", Map.of("name", "echo", "arguments", Map.of("message", "hi"))),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "echo"), reader());
+
+        assertThat(lastEchoUser, equalTo("test-user"));
+    }
+
+    @Test
     public void canCallToolWithBase64EncodedNameHeader() throws Exception {
         final String encoded = "=?base64?" + Base64.getEncoder().encodeToString("echo".getBytes(StandardCharsets.UTF_8)) + "?=";
         final McpRequestHandler.Result result = handler.handle(
                 request(3, "tools/call", Map.of("name", "echo", "arguments", Map.of("message", "hi"))),
-                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", encoded), false);
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", encoded), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
         assertThat(body(result).path("result").path("isError").asBoolean(), is(false));
@@ -264,18 +365,39 @@ public class McpRequestHandlerTest {
     public void toolExceptionsBecomeErrorResults() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 request(4, "tools/call", Map.of("name", "broken")),
-                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "broken"), false);
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "broken"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
-        final JsonNode callResult = body(result).path("result");
-        assertThat(callResult.path("isError").asBoolean(), is(true));
+        assertThat(body(result).path("result").path("isError").asBoolean(), is(true));
+    }
+
+    @Test
+    public void nullToolResultsBecomeErrorResults() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(4, "tools/call", Map.of("name", "null-result")),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "null-result"), reader());
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        assertThat(body(result).path("result").path("isError").asBoolean(), is(true));
+    }
+
+    @Test
+    public void unservableToolsCannotBeCalled() throws Exception {
+        for (String name : List.of("null-schema", "header-param")) {
+            final McpRequestHandler.Result result = handler.handle(
+                    request(5, "tools/call", Map.of("name", name)),
+                    headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", name), reader());
+
+            assertThat(result.getHttpStatus(), equalTo(200));
+            assertThat(body(result).path("error").path("code").asInt(), equalTo(-32602));
+        }
     }
 
     @Test
     public void unknownToolIsInvalidParams() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 request(5, "tools/call", Map.of("name", "nope")),
-                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "nope"), false);
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "nope"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
         assertThat(body(result).path("error").path("code").asInt(), equalTo(-32602));
@@ -287,18 +409,18 @@ public class McpRequestHandlerTest {
                 "MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "restricted");
 
         final McpRequestHandler.Result denied = handler.handle(
-                request(6, "tools/call", Map.of("name", "restricted")), h, false);
+                request(6, "tools/call", Map.of("name", "restricted")), h, reader());
         assertThat(body(denied).path("error").path("code").asInt(), equalTo(-32000));
 
         final McpRequestHandler.Result allowed = handler.handle(
-                request(6, "tools/call", Map.of("name", "restricted")), h, true);
+                request(6, "tools/call", Map.of("name", "restricted")), h, admin());
         assertThat(body(allowed).path("result").path("isError").asBoolean(), is(false));
     }
 
     @Test
     public void missingMethodHeaderIsRejected() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
-                request(7, "tools/list", Map.of()), headers("MCP-Protocol-Version", PV), false);
+                request(7, "tools/list", Map.of()), headers("MCP-Protocol-Version", PV), reader());
 
         assertThat(result.getHttpStatus(), equalTo(400));
         assertThat(body(result).path("error").path("code").asInt(), equalTo(-32020));
@@ -308,7 +430,7 @@ public class McpRequestHandlerTest {
     public void mismatchedNameHeaderIsRejected() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 request(8, "tools/call", Map.of("name", "echo")),
-                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "other"), false);
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "other"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(400));
         assertThat(body(result).path("error").path("code").asInt(), equalTo(-32020));
@@ -318,7 +440,7 @@ public class McpRequestHandlerTest {
     public void mismatchedProtocolVersionHeaderIsRejected() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 request(9, "tools/list", Map.of()),
-                headers("MCP-Protocol-Version", "2025-11-25", "Mcp-Method", "tools/list"), false);
+                headers("MCP-Protocol-Version", "2025-11-25", "Mcp-Method", "tools/list"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(400));
         assertThat(body(result).path("error").path("code").asInt(), equalTo(-32020));
@@ -328,7 +450,7 @@ public class McpRequestHandlerTest {
     public void unsupportedProtocolVersionIsRejected() throws Exception {
         final String body = request(10, "tools/list", Map.of()).replace(PV, "2025-11-25");
         final McpRequestHandler.Result result = handler.handle(body,
-                headers("MCP-Protocol-Version", "2025-11-25", "Mcp-Method", "tools/list"), false);
+                headers("MCP-Protocol-Version", "2025-11-25", "Mcp-Method", "tools/list"), reader());
 
         assertThat(result.getHttpStatus(), equalTo(400));
         final JsonNode error = body(result).path("error");
@@ -338,15 +460,11 @@ public class McpRequestHandlerTest {
     }
 
     @Test
-    public void unknownMethodIs404(){
-        try {
-            final McpRequestHandler.Result result = handler.handle(
-                    request(11, "resources/list", Map.of()), standardHeaders("resources/list"), false);
-            assertThat(result.getHttpStatus(), equalTo(404));
-            assertThat(body(result).path("error").path("code").asInt(), equalTo(-32601));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public void unknownMethodIs404() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(11, "resources/list", Map.of()), standardHeaders("resources/list"), reader());
+        assertThat(result.getHttpStatus(), equalTo(404));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32601));
     }
 
     @Test
@@ -355,7 +473,7 @@ public class McpRequestHandlerTest {
         // dual-era support answers with a stateless legacy InitializeResult.
         final McpRequestHandler.Result result = handler.handle(
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}",
-                headers(), false);
+                headers(), reader());
 
         assertThat(result.getHttpStatus(), equalTo(200));
         final JsonNode init = body(result).path("result");
@@ -368,7 +486,7 @@ public class McpRequestHandlerTest {
     public void legacyInitializeFallsBackToDefaultVersion() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\"}}",
-                headers(), false);
+                headers(), reader());
 
         assertThat(body(result).path("result").path("protocolVersion").asText(),
                 equalTo(McpRequestHandler.DEFAULT_LEGACY_VERSION));
@@ -379,31 +497,65 @@ public class McpRequestHandlerTest {
         // tools/list without _meta or Mcp-* headers is a legacy-era request
         final McpRequestHandler.Result list = handler.handle(
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
-                headers(), false);
+                headers(), reader());
         assertThat(list.getHttpStatus(), equalTo(200));
         final JsonNode listResult = body(list).path("result");
-        assertThat(listResult.path("tools").size(), equalTo(2));
+        assertThat(listResult.path("tools").size(), equalTo(3));
         assertThat(listResult.has("resultType"), is(false));
 
         final McpRequestHandler.Result call = handler.handle(
                 "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"echo\",\"arguments\":{\"message\":\"hi\"}}}",
-                headers(), false);
+                headers(), reader());
         assertThat(call.getHttpStatus(), equalTo(200));
         final JsonNode callResult = body(call).path("result");
         assertThat(callResult.path("content").get(0).path("text").asText(), equalTo("echo: hi"));
         assertThat(callResult.has("resultType"), is(false));
 
         final McpRequestHandler.Result ping = handler.handle(
-                "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"ping\"}", headers(), false);
+                "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"ping\"}", headers(), reader());
         assertThat(ping.getHttpStatus(), equalTo(200));
         assertThat(body(ping).path("result").isObject(), is(true));
+    }
+
+    @Test
+    public void legacyRequestsWithInconsistentHeadersAreRejected() throws Exception {
+        // A present Mcp-Method header must still match the body
+        final McpRequestHandler.Result mismatchedMethod = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+                headers("Mcp-Method", "tools/call"), reader());
+        assertThat(mismatchedMethod.getHttpStatus(), equalTo(400));
+        assertThat(body(mismatchedMethod).path("error").path("code").asInt(), equalTo(-32020));
+
+        // A modern protocol version header cannot be combined with a body lacking modern _meta
+        final McpRequestHandler.Result modernHeaderNoMeta = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+                headers("MCP-Protocol-Version", PV), reader());
+        assertThat(modernHeaderNoMeta.getHttpStatus(), equalTo(400));
+        assertThat(body(modernHeaderNoMeta).path("error").path("code").asInt(), equalTo(-32020));
+
+        // A present Mcp-Name header must still match the called tool
+        final McpRequestHandler.Result mismatchedName = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"echo\"}}",
+                headers("Mcp-Name", "other"), reader());
+        assertThat(mismatchedName.getHttpStatus(), equalTo(400));
+        assertThat(body(mismatchedName).path("error").path("code").asInt(), equalTo(-32020));
+    }
+
+    @Test
+    public void explicitNullIdIsInvalidRequest() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"tools/list\"}",
+                standardHeaders("tools/list"), reader());
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32600));
     }
 
     @Test
     public void notificationsAreAccepted() throws Exception {
         final McpRequestHandler.Result result = handler.handle(
                 "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}",
-                headers(), false);
+                headers(), reader());
 
         assertThat(result.getHttpStatus(), equalTo(202));
         assertThat(result.getBody(), nullValue());
@@ -411,7 +563,7 @@ public class McpRequestHandlerTest {
 
     @Test
     public void parseErrorsAreReported() throws Exception {
-        final McpRequestHandler.Result result = handler.handle("{nope", headers(), false);
+        final McpRequestHandler.Result result = handler.handle("{nope", headers(), reader());
 
         assertThat(result.getHttpStatus(), equalTo(400));
         final JsonNode response = body(result);
@@ -421,7 +573,7 @@ public class McpRequestHandlerTest {
 
     @Test
     public void invalidRequestsAreReported() throws Exception {
-        final McpRequestHandler.Result result = handler.handle("{\"jsonrpc\":\"1.0\"}", headers(), false);
+        final McpRequestHandler.Result result = handler.handle("{\"jsonrpc\":\"1.0\"}", headers(), reader());
 
         assertThat(result.getHttpStatus(), equalTo(400));
         assertThat(body(result).path("error").path("code").asInt(), equalTo(-32600));

--- a/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/McpRequestHandlerTest.java
+++ b/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/McpRequestHandlerTest.java
@@ -1,0 +1,429 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.integration.api.v1.mcp.McpToolProvider;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class McpRequestHandlerTest {
+    private static final String PV = McpRequestHandler.PROTOCOL_VERSION;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private McpRequestHandler handler;
+    private Map<String, Object> lastEchoArguments;
+
+    private class EchoTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            return "echo";
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "Echoes the message argument";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return "{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}},\"required\":[\"message\"]}";
+        }
+
+        @Override
+        public McpToolResult execute(Map<String, Object> arguments) {
+            lastEchoArguments = arguments;
+            return McpToolResult.text("echo: " + arguments.get("message"));
+        }
+    }
+
+    private static class RestrictedTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            return "restricted";
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "A write tool";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return "{\"type\":\"object\"}";
+        }
+
+        @Override
+        public boolean isWriteAccess() {
+            return true;
+        }
+
+        @Override
+        public McpToolResult execute(Map<String, Object> arguments) {
+            return McpToolResult.text("done");
+        }
+    }
+
+    private static class BrokenTool implements McpToolProvider {
+        @Override
+        public String getToolName() {
+            return "broken";
+        }
+
+        @Override
+        public String getToolDescription() {
+            return "Always throws";
+        }
+
+        @Override
+        public String getInputSchema() {
+            return "this is not json";
+        }
+
+        @Override
+        public McpToolResult execute(Map<String, Object> arguments) {
+            throw new IllegalStateException("boom");
+        }
+    }
+
+    @Before
+    public void setUp() {
+        handler = new McpRequestHandler(new ToolRegistry(
+                List.of(new EchoTool(), new RestrictedTool(), new BrokenTool()), List.of()));
+    }
+
+    private static Function<String, String> headers(String... namesAndValues) {
+        final Map<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (int i = 0; i < namesAndValues.length; i += 2) {
+            map.put(namesAndValues[i], namesAndValues[i + 1]);
+        }
+        return map::get;
+    }
+
+    private static Function<String, String> standardHeaders(String method) {
+        return headers("MCP-Protocol-Version", PV, "Mcp-Method", method);
+    }
+
+    private String request(Object id, String method, Map<String, Object> params) throws Exception {
+        final Map<String, Object> paramsWithMeta = new HashMap<>(params);
+        paramsWithMeta.put("_meta", Map.of(
+                "io.modelcontextprotocol/protocolVersion", PV,
+                "io.modelcontextprotocol/clientInfo", Map.of("name", "test-client", "version", "1.0.0"),
+                "io.modelcontextprotocol/clientCapabilities", Map.of()));
+        final Map<String, Object> message = new HashMap<>();
+        message.put("jsonrpc", "2.0");
+        if (id != null) {
+            message.put("id", id);
+        }
+        message.put("method", method);
+        message.put("params", paramsWithMeta);
+        return mapper.writeValueAsString(message);
+    }
+
+    private JsonNode body(McpRequestHandler.Result result) throws Exception {
+        return mapper.readTree(result.getBody());
+    }
+
+    @Test
+    public void canDiscover() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(1, "server/discover", Map.of()), standardHeaders("server/discover"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        final JsonNode response = body(result);
+        assertThat(response.path("id").asInt(), equalTo(1));
+        final JsonNode discover = response.path("result");
+        assertThat(discover.path("resultType").asText(), equalTo("complete"));
+        assertThat(discover.path("supportedVersions").get(0).asText(), equalTo(PV));
+        assertThat(discover.path("capabilities").has("tools"), is(true));
+        assertThat(discover.path("_meta").path("io.modelcontextprotocol/serverInfo").path("name").asText(),
+                equalTo(McpRequestHandler.SERVER_NAME));
+    }
+
+    @Test
+    public void discoverAnswersUnsupportedVersions() throws Exception {
+        // A client probing with a version we do not support still gets a discover result
+        final String body = request(1, "server/discover", Map.of())
+                .replace(PV, "1999-01-01");
+        final McpRequestHandler.Result result = handler.handle(body,
+                headers("MCP-Protocol-Version", "1999-01-01", "Mcp-Method", "server/discover"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        assertThat(body(result).path("result").path("supportedVersions").get(0).asText(), equalTo(PV));
+    }
+
+    @Test
+    public void canListTools() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(2, "tools/list", Map.of()), standardHeaders("tools/list"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        final JsonNode listResult = body(result).path("result");
+        assertThat(listResult.path("resultType").asText(), equalTo("complete"));
+        assertThat(listResult.path("cacheScope").asText(), equalTo("private"));
+        assertThat(listResult.path("ttlMs").isNumber(), is(true));
+
+        final JsonNode tools = listResult.path("tools");
+        // deterministic (alphabetical) order; write tools are hidden from read-only users
+        assertThat(tools.size(), equalTo(2));
+        assertThat(tools.get(0).path("name").asText(), equalTo("broken"));
+        assertThat(tools.get(1).path("name").asText(), equalTo("echo"));
+        assertThat(tools.get(1).path("inputSchema").path("type").asText(), equalTo("object"));
+        // invalid schema string falls back to an open object schema
+        assertThat(tools.get(0).path("inputSchema").path("type").asText(), equalTo("object"));
+    }
+
+    @Test
+    public void writeToolsAreListedForAdmins() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(2, "tools/list", Map.of()), standardHeaders("tools/list"), true);
+
+        final JsonNode tools = body(result).path("result").path("tools");
+        assertThat(tools.size(), equalTo(3));
+        assertThat(tools.get(2).path("name").asText(), equalTo("restricted"));
+    }
+
+    @Test
+    public void explicitNullIdIsInvalidRequest() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"tools/list\"}",
+                standardHeaders("tools/list"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32600));
+    }
+
+    @Test
+    public void canCallTool() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(3, "tools/call", Map.of("name", "echo", "arguments", Map.of("message", "hi"))),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "echo"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        final JsonNode callResult = body(result).path("result");
+        assertThat(callResult.path("resultType").asText(), equalTo("complete"));
+        assertThat(callResult.path("isError").asBoolean(), is(false));
+        assertThat(callResult.path("content").get(0).path("type").asText(), equalTo("text"));
+        assertThat(callResult.path("content").get(0).path("text").asText(), equalTo("echo: hi"));
+        assertThat(lastEchoArguments, equalTo(Map.of("message", "hi")));
+    }
+
+    @Test
+    public void canCallToolWithBase64EncodedNameHeader() throws Exception {
+        final String encoded = "=?base64?" + Base64.getEncoder().encodeToString("echo".getBytes(StandardCharsets.UTF_8)) + "?=";
+        final McpRequestHandler.Result result = handler.handle(
+                request(3, "tools/call", Map.of("name", "echo", "arguments", Map.of("message", "hi"))),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", encoded), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        assertThat(body(result).path("result").path("isError").asBoolean(), is(false));
+    }
+
+    @Test
+    public void toolExceptionsBecomeErrorResults() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(4, "tools/call", Map.of("name", "broken")),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "broken"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        final JsonNode callResult = body(result).path("result");
+        assertThat(callResult.path("isError").asBoolean(), is(true));
+    }
+
+    @Test
+    public void unknownToolIsInvalidParams() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(5, "tools/call", Map.of("name", "nope")),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "nope"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32602));
+    }
+
+    @Test
+    public void writeToolRequiresPrivileges() throws Exception {
+        final Function<String, String> h = headers(
+                "MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "restricted");
+
+        final McpRequestHandler.Result denied = handler.handle(
+                request(6, "tools/call", Map.of("name", "restricted")), h, false);
+        assertThat(body(denied).path("error").path("code").asInt(), equalTo(-32000));
+
+        final McpRequestHandler.Result allowed = handler.handle(
+                request(6, "tools/call", Map.of("name", "restricted")), h, true);
+        assertThat(body(allowed).path("result").path("isError").asBoolean(), is(false));
+    }
+
+    @Test
+    public void missingMethodHeaderIsRejected() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(7, "tools/list", Map.of()), headers("MCP-Protocol-Version", PV), false);
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32020));
+    }
+
+    @Test
+    public void mismatchedNameHeaderIsRejected() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(8, "tools/call", Map.of("name", "echo")),
+                headers("MCP-Protocol-Version", PV, "Mcp-Method", "tools/call", "Mcp-Name", "other"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32020));
+    }
+
+    @Test
+    public void mismatchedProtocolVersionHeaderIsRejected() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                request(9, "tools/list", Map.of()),
+                headers("MCP-Protocol-Version", "2025-11-25", "Mcp-Method", "tools/list"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32020));
+    }
+
+    @Test
+    public void unsupportedProtocolVersionIsRejected() throws Exception {
+        final String body = request(10, "tools/list", Map.of()).replace(PV, "2025-11-25");
+        final McpRequestHandler.Result result = handler.handle(body,
+                headers("MCP-Protocol-Version", "2025-11-25", "Mcp-Method", "tools/list"), false);
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        final JsonNode error = body(result).path("error");
+        assertThat(error.path("code").asInt(), equalTo(-32022));
+        assertThat(error.path("data").path("supported").get(0).asText(), equalTo(PV));
+        assertThat(error.path("data").path("requested").asText(), equalTo("2025-11-25"));
+    }
+
+    @Test
+    public void unknownMethodIs404(){
+        try {
+            final McpRequestHandler.Result result = handler.handle(
+                    request(11, "resources/list", Map.of()), standardHeaders("resources/list"), false);
+            assertThat(result.getHttpStatus(), equalTo(404));
+            assertThat(body(result).path("error").path("code").asInt(), equalTo(-32601));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void legacyInitializeNegotiatesRequestedVersion() throws Exception {
+        // Legacy clients send initialize without any of the modern headers or _meta;
+        // dual-era support answers with a stateless legacy InitializeResult.
+        final McpRequestHandler.Result result = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}",
+                headers(), false);
+
+        assertThat(result.getHttpStatus(), equalTo(200));
+        final JsonNode init = body(result).path("result");
+        assertThat(init.path("protocolVersion").asText(), equalTo("2025-11-25"));
+        assertThat(init.path("capabilities").has("tools"), is(true));
+        assertThat(init.path("serverInfo").path("name").asText(), equalTo(McpRequestHandler.SERVER_NAME));
+    }
+
+    @Test
+    public void legacyInitializeFallsBackToDefaultVersion() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\"}}",
+                headers(), false);
+
+        assertThat(body(result).path("result").path("protocolVersion").asText(),
+                equalTo(McpRequestHandler.DEFAULT_LEGACY_VERSION));
+    }
+
+    @Test
+    public void legacyRequestsWorkWithoutModernHeaders() throws Exception {
+        // tools/list without _meta or Mcp-* headers is a legacy-era request
+        final McpRequestHandler.Result list = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+                headers(), false);
+        assertThat(list.getHttpStatus(), equalTo(200));
+        final JsonNode listResult = body(list).path("result");
+        assertThat(listResult.path("tools").size(), equalTo(2));
+        assertThat(listResult.has("resultType"), is(false));
+
+        final McpRequestHandler.Result call = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"echo\",\"arguments\":{\"message\":\"hi\"}}}",
+                headers(), false);
+        assertThat(call.getHttpStatus(), equalTo(200));
+        final JsonNode callResult = body(call).path("result");
+        assertThat(callResult.path("content").get(0).path("text").asText(), equalTo("echo: hi"));
+        assertThat(callResult.has("resultType"), is(false));
+
+        final McpRequestHandler.Result ping = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"ping\"}", headers(), false);
+        assertThat(ping.getHttpStatus(), equalTo(200));
+        assertThat(body(ping).path("result").isObject(), is(true));
+    }
+
+    @Test
+    public void notificationsAreAccepted() throws Exception {
+        final McpRequestHandler.Result result = handler.handle(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}",
+                headers(), false);
+
+        assertThat(result.getHttpStatus(), equalTo(202));
+        assertThat(result.getBody(), nullValue());
+    }
+
+    @Test
+    public void parseErrorsAreReported() throws Exception {
+        final McpRequestHandler.Result result = handler.handle("{nope", headers(), false);
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        final JsonNode response = body(result);
+        assertThat(response.path("error").path("code").asInt(), equalTo(-32700));
+        assertThat(response.path("id").isNull(), is(true));
+    }
+
+    @Test
+    public void invalidRequestsAreReported() throws Exception {
+        final McpRequestHandler.Result result = handler.handle("{\"jsonrpc\":\"1.0\"}", headers(), false);
+
+        assertThat(result.getHttpStatus(), equalTo(400));
+        assertThat(body(result).path("error").path("code").asInt(), equalTo(-32600));
+    }
+}

--- a/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/tools/JsonSupportTest.java
+++ b/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/tools/JsonSupportTest.java
@@ -41,9 +41,29 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.opennms.integration.api.v1.dao.AlarmDao;
+import org.opennms.integration.api.v1.mcp.McpToolContext;
 import org.opennms.integration.api.v1.mcp.McpToolResult;
 
 public class JsonSupportTest {
+
+    private static McpToolContext context(Map<String, Object> arguments) {
+        return new McpToolContext() {
+            @Override
+            public Map<String, Object> getArguments() {
+                return arguments;
+            }
+
+            @Override
+            public String getUserName() {
+                return "test-user";
+            }
+
+            @Override
+            public boolean isUserInRole(String role) {
+                return false;
+            }
+        };
+    }
 
     @Test
     public void exactIntAcceptsIntegralNumbers() {
@@ -70,11 +90,22 @@ public class JsonSupportTest {
     @Test
     public void updateAlarmsRejectsWrappingIdsWithoutTouchingDao() {
         final AlarmDao alarmDao = mock(AlarmDao.class);
-        final McpToolResult result = new UpdateAlarmsTool(alarmDao).execute(Map.of(
+        final McpToolResult result = new UpdateAlarmsTool(alarmDao).execute(context(Map.of(
                 "alarmIds", List.of(4294967297L),
-                "action", "clear"));
+                "action", "clear")));
 
         assertThat(result.isError(), equalTo(true));
         verify(alarmDao, never()).clear(any(int[].class));
+    }
+
+    @Test
+    public void updateAlarmsRecordsTheAuthenticatedUser() {
+        final AlarmDao alarmDao = mock(AlarmDao.class);
+        final McpToolResult result = new UpdateAlarmsTool(alarmDao).execute(context(Map.of(
+                "alarmIds", List.of(7),
+                "action", "acknowledge")));
+
+        assertThat(result.isError(), equalTo(false));
+        verify(alarmDao).acknowledge("test-user", 7);
     }
 }

--- a/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/tools/JsonSupportTest.java
+++ b/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/tools/JsonSupportTest.java
@@ -99,6 +99,33 @@ public class JsonSupportTest {
     }
 
     @Test
+    public void ipLiteralsAreRecognized() {
+        for (String valid : List.of("192.168.1.1", "10.0.0.255", "::1", "fe80::1%en0",
+                "2001:db8::8a2e:370:7334", "::ffff:192.0.2.1")) {
+            assertThat(valid, FindNodeByIpTool.isIpLiteral(valid), equalTo(true));
+        }
+        for (String invalid : List.of("example.com", "localhost", "999.1.1.1", "1.2.3",
+                "1.2.3.4.5", "a.b.c.d", "192.168.1.")) {
+            assertThat(invalid, FindNodeByIpTool.isIpLiteral(invalid), equalTo(false));
+        }
+    }
+
+    @Test
+    public void findNodeByIpRejectsHostNamesWithoutResolving() {
+        final org.opennms.integration.api.v1.dao.InterfaceToNodeCache cache =
+                mock(org.opennms.integration.api.v1.dao.InterfaceToNodeCache.class);
+        final org.opennms.integration.api.v1.dao.NodeDao nodeDao =
+                mock(org.opennms.integration.api.v1.dao.NodeDao.class);
+        final FindNodeByIpTool tool = new FindNodeByIpTool(cache, nodeDao);
+
+        for (String bad : List.of("example.com", "", "   ")) {
+            final McpToolResult result = tool.execute(context(Map.of("ip", bad)));
+            assertThat(result.isError(), equalTo(true));
+        }
+        verify(cache, never()).getFirstNodeId(any(), any());
+    }
+
+    @Test
     public void updateAlarmsRecordsTheAuthenticatedUser() {
         final AlarmDao alarmDao = mock(AlarmDao.class);
         final McpToolResult result = new UpdateAlarmsTool(alarmDao).execute(context(Map.of(

--- a/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/tools/JsonSupportTest.java
+++ b/mcp-server/src/test/java/org/opennms/integration/api/mcpserver/tools/JsonSupportTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2026 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2026 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License Version 2.0 as published
+ * by the Apache Software Foundation.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License Version 2.0 for more details.
+ *
+ * You should have received a copy of the Apache License Version 2.0
+ * along with OpenNMS(R).  If not, see:
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.integration.api.mcpserver.tools;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.dao.AlarmDao;
+import org.opennms.integration.api.v1.mcp.McpToolResult;
+
+public class JsonSupportTest {
+
+    @Test
+    public void exactIntAcceptsIntegralNumbers() {
+        assertThat(JsonSupport.exactInt(42, "x"), equalTo(42));
+        assertThat(JsonSupport.exactInt(42L, "x"), equalTo(42));
+        assertThat(JsonSupport.exactInt(42.0d, "x"), equalTo(42));
+        assertThat(JsonSupport.exactInt(BigInteger.valueOf(42), "x"), equalTo(42));
+    }
+
+    @Test
+    public void exactIntRejectsTruncationAndWrapping() {
+        // 4294967297 wraps to 1 under Number.intValue(); it must be rejected instead
+        for (Object bad : List.of(4294967297L, 4294967297.0d, 1.5d,
+                BigInteger.valueOf(2).pow(80), "42")) {
+            try {
+                JsonSupport.exactInt(bad, "x");
+                fail("Expected rejection of " + bad);
+            } catch (IllegalArgumentException expected) {
+                // expected
+            }
+        }
+    }
+
+    @Test
+    public void updateAlarmsRejectsWrappingIdsWithoutTouchingDao() {
+        final AlarmDao alarmDao = mock(AlarmDao.class);
+        final McpToolResult result = new UpdateAlarmsTool(alarmDao).execute(Map.of(
+                "alarmIds", List.of(4294967297L),
+                "action", "clear"));
+
+        assertThat(result.isError(), equalTo(true));
+        verify(alarmDao, never()).clear(any(int[].class));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <module>utils</module>
         <module>karaf-features</module>
         <module>sample</module>
+        <module>mcp-server</module>
         <module>test-api</module>
         <module>config</module>
         <module>test-suites</module>
@@ -50,6 +51,7 @@
         <javax-activation.version>1.1.1</javax-activation.version>
         <junit.version>4.13.2</junit.version>
         <guava.version>33.2.1-jre</guava.version>
+        <jackson.version>2.18.7</jackson.version>
         <karaf.version>4.3.6</karaf.version>
         <log4j.version>2.23.1</log4j.version>
         <re2j.version>1.7</re2j.version>


### PR DESCRIPTION
New `opennms-mcp-server` Karaf feature, installable with `feature:install opennms-mcp-server`.

## Built-in tools

| Tool | Access | Description |
| --- | --- | --- |
| `list_nodes` | read | List/search the node inventory |
| `get_node` | read | Node details including IP interfaces and services |
| `list_alarms` | read | List alarms, filtered by severity/acknowledgement |
| `find_node_by_ip` | read | Resolve an IP address to a node |
| `update_alarms` | write | Acknowledge/unacknowledge/escalate/clear alarms |
| `send_event` | write | Send an event onto the event bus |

Any plugin can contribute tools by publishing an `org.opennms.integration.api.v1.mcp.McpToolProvider` OSGi service; the server picks them up dynamically and advertises them via `tools/list`.

### External References

* Jira (Issue Tracker): https://opennms.atlassian.net/browse/NMS-20219
